### PR TITLE
add embolden to draw glyphs

### DIFF
--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -126,6 +126,7 @@ pub trait PaintScene {
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [NormalizedCoord],
+        embolden: kurbo::Vec2,
         style: impl Into<StyleRef<'a>>,
         brush: impl Into<PaintRef<'a>>,
         brush_alpha: f32,

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -119,6 +119,7 @@ impl PaintScene for NullScenePainter {
         _font_size: f32,
         _hint: bool,
         _normalized_coords: &'a [crate::NormalizedCoord],
+        _embolden: kurbo::Vec2,
         _style: impl Into<peniko::StyleRef<'a>>,
         _brush: impl Into<crate::PaintRef<'a>>,
         _brush_alpha: f32,

--- a/crates/anyrender_skia/src/scene.rs
+++ b/crates/anyrender_skia/src/scene.rs
@@ -437,6 +437,7 @@ impl PaintScene for SkiaScenePainter<'_> {
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [anyrender::NormalizedCoord],
+        _embolden: kurbo::Vec2,
         style: impl Into<peniko::StyleRef<'a>>,
         brush: impl Into<anyrender::PaintRef<'a>>,
         brush_alpha: f32,

--- a/crates/anyrender_vello/src/scene.rs
+++ b/crates/anyrender_vello/src/scene.rs
@@ -115,6 +115,7 @@ impl PaintScene for VelloScenePainter<'_, '_> {
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [NormalizedCoord],
+        _embolden: kurbo::Vec2,
         style: impl Into<StyleRef<'a>>,
         paint: impl Into<PaintRef<'a>>,
         brush_alpha: f32,

--- a/crates/anyrender_vello_cpu/src/scene.rs
+++ b/crates/anyrender_vello_cpu/src/scene.rs
@@ -107,6 +107,7 @@ impl PaintScene for VelloCpuScenePainter {
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [NormalizedCoord],
+        _embolden: kurbo::Vec2,
         style: impl Into<StyleRef<'a>>,
         paint: impl Into<PaintRef<'a>>,
         _brush_alpha: f32,

--- a/crates/anyrender_vello_hybrid/src/scene.rs
+++ b/crates/anyrender_vello_hybrid/src/scene.rs
@@ -149,6 +149,7 @@ impl PaintScene for VelloHybridScenePainter<'_> {
         font_size: f32,
         hint: bool,
         normalized_coords: &'a [NormalizedCoord],
+        _embolden: kurbo::Vec2,
         style: impl Into<StyleRef<'a>>,
         paint: impl Into<PaintRef<'a>>,
         _brush_alpha: f32,


### PR DESCRIPTION
This isn't yet implemented in any renderer but we will support it in tiny skia and vger and it could very soon be supported in Vello and I still plan to port the path expansion code to kurbo for more general support