### PR TITLE
Add `push_clip_layer`

### DIFF
--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -98,7 +98,7 @@ pub trait PaintScene {
     /// Pushes a new clip layer clipped by the specified shape.
     /// Every drawing command after this call will be clipped by the shape until the layer is popped.
     /// However, the transforms are not saved or modified by the layer stack.
-    fn push_clip_layer(&mut self, clip: &impl Shape);
+    fn push_clip_layer(&mut self, transform: Affine, clip: &impl Shape);
 
     /// Pops the current layer.
     fn pop_layer(&mut self);

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -91,7 +91,7 @@ impl PaintScene for NullScenePainter {
     ) {
     }
 
-    fn push_clip_layer(&mut self, _clip: &impl kurbo::Shape) {}
+    fn push_clip_layer(&mut self, _transform: kurbo::Affine, _clip: &impl kurbo::Shape) {}
 
     fn pop_layer(&mut self) {}
 

--- a/crates/anyrender_skia/src/scene.rs
+++ b/crates/anyrender_skia/src/scene.rs
@@ -394,10 +394,10 @@ impl PaintScene for SkiaScenePainter<'_> {
         }
     }
 
-    fn push_clip_layer(&mut self, clip: &impl kurbo::Shape) {
+    fn push_clip_layer(&mut self, transform: kurbo::Affine, clip: &impl kurbo::Shape) {
         self.inner.save(); // we need to do two saves because of pop_layer
 
-        self.set_matrix(kurbo::Affine::IDENTITY);
+        self.set_matrix(transform);
         self.clip(clip);
         self.inner.save();
     }

--- a/crates/anyrender_vello/src/scene.rs
+++ b/crates/anyrender_vello/src/scene.rs
@@ -60,8 +60,8 @@ impl PaintScene for VelloScenePainter<'_, '_> {
         self.inner.push_layer(blend, alpha, transform, clip);
     }
 
-    fn push_clip_layer(&mut self, clip: &impl Shape) {
-        self.inner.push_clip_layer(Affine::IDENTITY, clip);
+    fn push_clip_layer(&mut self, transform: Affine, clip: &impl Shape) {
+        self.inner.push_clip_layer(transform, clip);
     }
 
     fn pop_layer(&mut self) {

--- a/crates/anyrender_vello_cpu/src/scene.rs
+++ b/crates/anyrender_vello_cpu/src/scene.rs
@@ -63,8 +63,8 @@ impl PaintScene for VelloCpuScenePainter {
         );
     }
 
-    fn push_clip_layer(&mut self, clip: &impl Shape) {
-        self.0.set_transform(Affine::IDENTITY);
+    fn push_clip_layer(&mut self, transform: Affine, clip: &impl Shape) {
+        self.0.set_transform(transform);
         self.0.push_clip_layer(&clip.into_path(DEFAULT_TOLERANCE));
     }
 

--- a/crates/anyrender_vello_hybrid/src/scene.rs
+++ b/crates/anyrender_vello_hybrid/src/scene.rs
@@ -103,8 +103,8 @@ impl PaintScene for VelloHybridScenePainter<'_> {
         );
     }
 
-    fn push_clip_layer(&mut self, clip: &impl Shape) {
-        self.scene.set_transform(Affine::IDENTITY);
+    fn push_clip_layer(&mut self, transform: Affine, clip: &impl Shape) {
+        self.scene.set_transform(transform);
         self.scene
             .push_clip_layer(&clip.into_path(DEFAULT_TOLERANCE));
     }


### PR DESCRIPTION
Peniko's `Mix::Clip` is deprecated, the correct way is to use `push_clip_layer`.

Initially I added function without transform argument, but we need to set transform to identity everywhere anyway (backends will then transform clip anyway), so I added it as an argument in second commit (this way users do not need to apply transform on clip by themself as backend will apply transform too).

Part of https://github.com/DioxusLabs/anyrender/issues/29