### PR TITLE
Support transparency on Vello and Skia backends

### DIFF
--- a/crates/anyrender_skia/src/image_renderer.rs
+++ b/crates/anyrender_skia/src/image_renderer.rs
@@ -64,6 +64,7 @@ impl ImageRenderer for SkiaImageRenderer {
         draw_fn(&mut SkiaScenePainter {
             inner: surface.canvas(),
             cache: &mut self.scene_cache,
+            base_color: Color::WHITE,
         });
         timer.record_time("render");
 
@@ -89,6 +90,7 @@ impl ImageRenderer for SkiaImageRenderer {
         draw_fn(&mut SkiaScenePainter {
             inner: surface.canvas(),
             cache: &mut self.scene_cache,
+            base_color: Color::WHITE,
         });
         timer.record_time("render");
 

--- a/crates/anyrender_skia/src/scene.rs
+++ b/crates/anyrender_skia/src/scene.rs
@@ -54,6 +54,7 @@ impl Default for SkiaSceneCache {
 pub struct SkiaScenePainter<'a> {
     pub(crate) inner: &'a Canvas,
     pub(crate) cache: &'a mut SkiaSceneCache,
+    pub(crate) base_color: Color,
 }
 
 impl SkiaScenePainter<'_> {
@@ -364,7 +365,7 @@ impl SkiaScenePainter<'_> {
 
 impl PaintScene for SkiaScenePainter<'_> {
     fn reset(&mut self) {
-        self.inner.clear(Color::WHITE);
+        self.inner.clear(self.base_color);
     }
 
     fn push_layer(

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -25,6 +25,7 @@ struct ActiveRenderState {
 
 pub struct SkiaWindowRenderer {
     render_state: RenderState,
+    base_color: Color,
 }
 
 impl Default for SkiaWindowRenderer {
@@ -37,6 +38,14 @@ impl SkiaWindowRenderer {
     pub fn new() -> Self {
         Self {
             render_state: RenderState::Suspended,
+            base_color: Color::WHITE,
+        }
+    }
+    pub fn with_base_color(base_color: peniko::Color) -> Self {
+        let base_color = base_color.to_rgba8();
+        Self {
+            render_state: RenderState::Suspended,
+            base_color: Color::from_argb(base_color.a, base_color.r, base_color.g, base_color.b),
         }
     }
 }
@@ -92,11 +101,12 @@ impl WindowRenderer for SkiaWindowRenderer {
         };
 
         surface.canvas().restore_to_count(1);
-        surface.canvas().clear(Color::WHITE);
+        surface.canvas().clear(self.base_color);
 
         draw_fn(&mut SkiaScenePainter {
             inner: surface.canvas(),
             cache: &mut state.scene_cache,
+            base_color: self.base_color,
         });
         timer.record_time("cmd");
 

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -128,6 +128,12 @@ impl WindowRenderer for VelloWindowRenderer {
     }
 
     fn resume(&mut self, window_handle: Arc<dyn WindowHandle>, width: u32, height: u32) {
+        let alpha_mode = if self.config.base_color.components[3] < 1.0 {
+            wgpu::CompositeAlphaMode::PreMultiplied
+        } else {
+            wgpu::CompositeAlphaMode::Auto
+        };
+
         // Create wgpu_context::SurfaceRenderer
         let render_surface = pollster::block_on(self.wgpu_context.create_surface(
             window_handle.clone(),
@@ -138,7 +144,7 @@ impl WindowRenderer for VelloWindowRenderer {
                 height,
                 present_mode: PresentMode::AutoVsync,
                 desired_maximum_frame_latency: 2,
-                alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                alpha_mode,
                 view_formats: vec![],
             },
             Some(TextureConfiguration {


### PR DESCRIPTION
Support transparency on Vello and Skia backends

Supporting this for Vello CPU is dependent on these:
https://github.com/parasyte/pixels/issues/274
https://github.com/rust-windowing/softbuffer/issues/17

Also, the Skia image renderer uses a white base color, while the other image renderers use a transparent base color. I didn't change this, but it probably should be changed.