### PR TITLE
Use `RenderContext` to own resource lifecycle outside of scene rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ dependencies = [
  "kurbo",
  "peniko",
  "raw-window-handle",
+ "rustc-hash 2.1.1",
  "serde",
 ]
 
@@ -171,7 +172,8 @@ dependencies = [
  "image",
  "kurbo",
  "peniko",
- "read-fonts 0.37.0",
+ "read-fonts 0.37.0 (git+https://github.com/googlefonts/fontations?rev=41ec2bdd6dd8589b65eaaaf182b0a2e701d0d826)",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sha2",
@@ -203,6 +205,7 @@ dependencies = [
  "peniko",
  "pixels_window_renderer",
  "raw-window-handle",
+ "rustc-hash 2.1.1",
  "skia-safe",
  "softbuffer_window_renderer",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "image",
  "kurbo",
  "peniko",
- "read-fonts 0.37.0 (git+https://github.com/googlefonts/fontations?rev=41ec2bdd6dd8589b65eaaaf182b0a2e701d0d826)",
+ "read-fonts 0.37.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/crates/anyrender/Cargo.toml
+++ b/crates/anyrender/Cargo.toml
@@ -20,6 +20,7 @@ serde = [
 kurbo = { workspace = true }
 peniko = { workspace = true }
 raw-window-handle = { workspace = true }
+rustc-hash = { workspace = true }
 
 # Serde
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -187,7 +187,7 @@ pub trait PaintScene {
                     match &cmd.brush {
                         Brush::Solid(alpha_color) => Paint::Solid(*alpha_color),
                         Brush::Gradient(gradient) => Paint::Gradient(gradient),
-                        Brush::Image(image) => Paint::Image(image.clone()),
+                        Brush::Image(image) => Paint::Image(*image),
                     },
                     cmd.brush_transform,
                     &cmd.shape,
@@ -198,7 +198,7 @@ pub trait PaintScene {
                     match &cmd.brush {
                         Brush::Solid(alpha_color) => Paint::Solid(*alpha_color),
                         Brush::Gradient(gradient) => Paint::Gradient(gradient),
-                        Brush::Image(image) => Paint::Image(image.clone()),
+                        Brush::Image(image) => Paint::Image(*image),
                     },
                     cmd.brush_transform,
                     &cmd.shape,
@@ -212,7 +212,7 @@ pub trait PaintScene {
                     match &cmd.brush {
                         Brush::Solid(alpha_color) => Paint::Solid(*alpha_color),
                         Brush::Gradient(gradient) => Paint::Gradient(gradient),
-                        Brush::Image(image) => Paint::Image(image.clone()),
+                        Brush::Image(image) => Paint::Image(*image),
                     },
                     cmd.brush_alpha,
                     scene_transform * cmd.transform,

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -1,31 +1,10 @@
-//! A dummy implementation of the AnyRender traits while simply ignores all commands
+//! A dummy implementation of the AnyRender traits that simply ignores all commands
 
 use crate::{
     ImageRenderer, ImageResource, PaintScene, RenderContext, ResourceId, WindowHandle,
     WindowRenderer,
 };
 use std::sync::Arc;
-
-#[derive(Default)]
-pub struct NullRenderContext {}
-
-impl NullRenderContext {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl RenderContext for NullRenderContext {
-    fn register_image(&mut self, image: peniko::ImageData) -> ImageResource {
-        ImageResource {
-            id: ResourceId(0),
-            width: image.width,
-            height: image.height,
-        }
-    }
-
-    fn unregister_resource(&mut self, _id: ResourceId) {}
-}
 
 #[derive(Copy, Clone, Default)]
 pub struct NullWindowRenderer {
@@ -38,12 +17,23 @@ impl NullWindowRenderer {
     }
 }
 
+impl RenderContext for NullWindowRenderer {
+    fn register_image(&mut self, image: peniko::ImageData) -> ImageResource {
+        ImageResource {
+            id: ResourceId(0),
+            width: image.width,
+            height: image.height,
+        }
+    }
+
+    fn unregister_resource(&mut self, _id: ResourceId) {}
+}
+
 impl WindowRenderer for NullWindowRenderer {
     type ScenePainter<'a>
         = NullScenePainter
     where
         Self: 'a;
-    type Context = NullRenderContext;
 
     fn resume(&mut self, _window: Arc<dyn WindowHandle>, _width: u32, _height: u32) {
         self.is_active = true;
@@ -59,12 +49,7 @@ impl WindowRenderer for NullWindowRenderer {
 
     fn set_size(&mut self, _width: u32, _height: u32) {}
 
-    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(
-        &mut self,
-        _ctx: &mut Self::Context,
-        _draw_fn: F,
-    ) {
-    }
+    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, _draw_fn: F) {}
 }
 
 #[derive(Clone, Default)]
@@ -76,12 +61,23 @@ impl NullImageRenderer {
     }
 }
 
+impl RenderContext for NullImageRenderer {
+    fn register_image(&mut self, image: peniko::ImageData) -> ImageResource {
+        ImageResource {
+            id: ResourceId(0),
+            width: image.width,
+            height: image.height,
+        }
+    }
+
+    fn unregister_resource(&mut self, _id: ResourceId) {}
+}
+
 impl ImageRenderer for NullImageRenderer {
     type ScenePainter<'a>
         = NullScenePainter
     where
         Self: 'a;
-    type Context = NullRenderContext;
 
     fn new(_width: u32, _height: u32) -> Self {
         Self
@@ -93,7 +89,6 @@ impl ImageRenderer for NullImageRenderer {
 
     fn render_to_vec<F: FnOnce(&mut Self::ScenePainter<'_>)>(
         &mut self,
-        _ctx: &mut Self::Context,
         _draw_fn: F,
         _vec: &mut Vec<u8>,
     ) {
@@ -101,7 +96,6 @@ impl ImageRenderer for NullImageRenderer {
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(
         &mut self,
-        _ctx: &mut Self::Context,
         _draw_fn: F,
         _buffer: &mut [u8],
     ) {

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -1,7 +1,31 @@
 //! A dummy implementation of the AnyRender traits while simply ignores all commands
 
-use crate::{ImageRenderer, PaintScene, WindowHandle, WindowRenderer};
+use crate::{
+    ImageRenderer, ImageResource, PaintScene, RenderContext, ResourceId, WindowHandle,
+    WindowRenderer,
+};
 use std::sync::Arc;
+
+#[derive(Default)]
+pub struct NullRenderContext {}
+
+impl NullRenderContext {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl RenderContext for NullRenderContext {
+    fn register_image(&mut self, image: peniko::ImageData) -> ImageResource {
+        ImageResource {
+            id: ResourceId(0),
+            width: image.width,
+            height: image.height,
+        }
+    }
+
+    fn unregister_resource(&mut self, _id: ResourceId) {}
+}
 
 #[derive(Copy, Clone, Default)]
 pub struct NullWindowRenderer {
@@ -19,6 +43,7 @@ impl WindowRenderer for NullWindowRenderer {
         = NullScenePainter
     where
         Self: 'a;
+    type Context = NullRenderContext;
 
     fn resume(&mut self, _window: Arc<dyn WindowHandle>, _width: u32, _height: u32) {
         self.is_active = true;
@@ -34,15 +59,20 @@ impl WindowRenderer for NullWindowRenderer {
 
     fn set_size(&mut self, _width: u32, _height: u32) {}
 
-    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, _draw_fn: F) {}
+    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(
+        &mut self,
+        _ctx: &mut Self::Context,
+        _draw_fn: F,
+    ) {
+    }
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct NullImageRenderer;
 
 impl NullImageRenderer {
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 }
 
@@ -51,9 +81,10 @@ impl ImageRenderer for NullImageRenderer {
         = NullScenePainter
     where
         Self: 'a;
+    type Context = NullRenderContext;
 
     fn new(_width: u32, _height: u32) -> Self {
-        Self
+        Self::default()
     }
 
     fn resize(&mut self, _width: u32, _height: u32) {}
@@ -62,12 +93,19 @@ impl ImageRenderer for NullImageRenderer {
 
     fn render_to_vec<F: FnOnce(&mut Self::ScenePainter<'_>)>(
         &mut self,
+        _ctx: &mut Self::Context,
         _draw_fn: F,
         _vec: &mut Vec<u8>,
     ) {
     }
 
-    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, _draw_fn: F, _buffer: &mut [u8]) {}
+    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(
+        &mut self,
+        _ctx: &mut Self::Context,
+        _draw_fn: F,
+        _buffer: &mut [u8],
+    ) {
+    }
 }
 
 #[derive(Copy, Clone, Default)]

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -72,7 +72,7 @@ pub struct NullImageRenderer;
 
 impl NullImageRenderer {
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 }
 
@@ -84,7 +84,7 @@ impl ImageRenderer for NullImageRenderer {
     type Context = NullRenderContext;
 
     fn new(_width: u32, _height: u32) -> Self {
-        Self::default()
+        Self
     }
 
     fn resize(&mut self, _width: u32, _height: u32) {}

--- a/crates/anyrender/src/recording.rs
+++ b/crates/anyrender/src/recording.rs
@@ -159,7 +159,7 @@ impl Scene {
         match paint_ref {
             Paint::Solid(color) => Brush::Solid(color),
             Paint::Gradient(gradient) => Brush::Gradient(gradient.clone()),
-            Paint::Image(image) => Brush::Image(image.clone()),
+            Paint::Image(image) => Brush::Image(image),
             // TODO: handle this somehow
             Paint::Custom(_) => Brush::Solid(Color::TRANSPARENT),
         }

--- a/crates/anyrender/src/recording.rs
+++ b/crates/anyrender/src/recording.rs
@@ -296,10 +296,10 @@ impl PaintScene for Scene {
     }
 }
 
-/// A simple [`RenderContext`] for use with recording scenes.
+/// A [`RenderContext`] for use with recording scenes.
 ///
 /// This context assigns [`ResourceId`]s and stores the associated [`ImageData`] in a
-/// `HashMap` so that recorded scenes can later be serialized or replayed through a
+/// [`FxHashMap`] so that recorded scenes can later be serialized or replayed through a
 /// backend-specific context.
 pub struct RecordingRenderContext {
     image_data: FxHashMap<ResourceId, ImageData>,

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -75,7 +75,7 @@ impl Paint {
         match self {
             Paint::Solid(color) => Paint::Solid(*color),
             Paint::Gradient(gradient) => Paint::Gradient(gradient),
-            Paint::Image(image) => Paint::Image(image.clone()),
+            Paint::Image(image) => Paint::Image(*image),
 
             // Custom paints are translated into "invisible" where they are not supported
             Paint::Custom(custom) => Paint::Custom(custom.as_ref()),

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -1,12 +1,37 @@
 //! Types that are used within the Anyrender traits
 
-use peniko::{Brush, BrushRef, Color, Gradient, ImageBrush, ImageBrushRef};
+use peniko::{Color, Gradient, ImageBrush, ImageData};
 use std::{any::Any, sync::Arc};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 pub type NormalizedCoord = i16;
+
+/// Opaque handle to a registered resource managed by a [`RenderContext`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ResourceId(pub u64);
+
+/// A registered image resource that combines a [`ResourceId`] with the image dimensions.
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ImageResource {
+    pub id: ResourceId,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Renderers implement this trait to handle resource allocation/deallocation separately
+/// from scene construction. Resources are registered once and then referenced by
+/// [`ResourceId`] during painting.
+pub trait RenderContext {
+    /// Register an image and upload/convert it into a backend-specific backing resource.
+    fn register_image(&mut self, image: ImageData) -> ImageResource;
+
+    /// Unregister a previously registered resource, freeing any backing storage.
+    fn unregister_resource(&mut self, id: ResourceId);
+}
 
 /// A positioned glyph.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -28,7 +53,7 @@ pub struct CustomPaint {
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Paint<I = ImageBrush, G = Gradient, C = Arc<dyn Any + Send + Sync>> {
+pub enum Paint<I = ImageBrush<ImageResource>, G = Gradient, C = Arc<dyn Any + Send + Sync>> {
     /// Solid color brush.
     Solid(Color),
     /// Gradient brush.
@@ -39,14 +64,18 @@ pub enum Paint<I = ImageBrush, G = Gradient, C = Arc<dyn Any + Send + Sync>> {
     Custom(C),
 }
 
-pub type PaintRef<'a> = Paint<ImageBrushRef<'a>, &'a Gradient, &'a (dyn Any + Send + Sync)>;
+/// A reference-friendly version of [`Paint`] used in [`PaintScene`](crate::PaintScene) method signatures.
+///
+/// Images are referenced by [`ImageResource`] (containing a [`ResourceId`]) rather than
+/// by raw pixel data.
+pub type PaintRef<'a> = Paint<ImageBrush<ImageResource>, &'a Gradient, &'a (dyn Any + Send + Sync)>;
 
 impl Paint {
     pub fn as_ref(&self) -> PaintRef<'_> {
         match self {
             Paint::Solid(color) => Paint::Solid(*color),
             Paint::Gradient(gradient) => Paint::Gradient(gradient),
-            Paint::Image(image) => Paint::Image(image.as_ref()),
+            Paint::Image(image) => Paint::Image(image.clone()),
 
             // Custom paints are translated into "invisible" where they are not supported
             Paint::Custom(custom) => Paint::Custom(custom.as_ref()),
@@ -60,31 +89,6 @@ impl<'a> From<&'a Paint> for PaintRef<'a> {
     }
 }
 
-impl<'a> From<PaintRef<'a>> for BrushRef<'a> {
-    fn from(value: PaintRef<'a>) -> Self {
-        match value {
-            Paint::Solid(color) => Brush::Solid(color),
-            Paint::Gradient(gradient) => Brush::Gradient(gradient),
-            Paint::Image(image) => Brush::Image(image),
-
-            // Custom paints are translated into "invisible" where they are not supported
-            Paint::Custom(_) => Brush::Solid(Color::TRANSPARENT),
-        }
-    }
-}
-
-// #[derive(Clone, Debug)]
-// pub enum PaintRef<'a> {
-//     /// Solid color brush.
-//     Solid(Color),
-//     /// Gradient brush.
-//     Gradient(&'a Gradient),
-//     /// Image brush.
-//     Image(ImageBrushRef<'a>),
-//     /// Custom paint (type erased as each backend will have their own)
-//     Custom(Arc<dyn Any + Send + Sync>),
-// }
-
 impl<I, G, C> From<Color> for Paint<I, G, C> {
     fn from(value: Color) -> Self {
         Paint::Solid(value)
@@ -95,22 +99,13 @@ impl<'a, I, C> From<&'a Gradient> for Paint<I, &'a Gradient, C> {
         Paint::Gradient(value)
     }
 }
-impl<'a, G, C> From<ImageBrushRef<'a>> for Paint<ImageBrushRef<'a>, G, C> {
-    fn from(value: ImageBrushRef<'a>) -> Self {
+impl<G, C> From<ImageBrush<ImageResource>> for Paint<ImageBrush<ImageResource>, G, C> {
+    fn from(value: ImageBrush<ImageResource>) -> Self {
         Paint::Image(value)
     }
 }
 impl<I, G> From<Arc<dyn Any + Send + Sync>> for Paint<I, G, Arc<dyn Any + Send + Sync>> {
     fn from(value: Arc<dyn Any + Send + Sync>) -> Self {
         Paint::Custom(value)
-    }
-}
-impl<'a> From<BrushRef<'a>> for PaintRef<'a> {
-    fn from(value: BrushRef<'a>) -> Self {
-        match value {
-            BrushRef::Solid(color) => PaintRef::Solid(color),
-            BrushRef::Gradient(gradient) => PaintRef::Gradient(gradient),
-            BrushRef::Image(image) => PaintRef::Image(image),
-        }
     }
 }

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -1,6 +1,7 @@
 //! Types that are used within the Anyrender traits
 
-use peniko::{Color, Gradient, ImageBrush, ImageData};
+pub use peniko::ImageData;
+use peniko::{Color, Gradient, ImageBrush};
 use std::{any::Any, sync::Arc};
 
 #[cfg(feature = "serde")]

--- a/crates/anyrender_serialize/Cargo.toml
+++ b/crates/anyrender_serialize/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace = true
 anyrender = { workspace = true, features = ["serde"] }
 peniko = { workspace = true }
 
+rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 zip = { workspace = true }
@@ -25,6 +26,7 @@ wuff = { workspace = true }
 [dev-dependencies]
 kurbo = { workspace = true }
 peniko = { workspace = true }
+rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 wuff = { workspace = true }
 zip = { workspace = true }

--- a/crates/anyrender_serialize/src/font_writer.rs
+++ b/crates/anyrender_serialize/src/font_writer.rs
@@ -1,6 +1,6 @@
 //! Write-side font processing: collection, deduplication, subsetting, and encoding.
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use peniko::FontData;
 use read_fonts::FontRef;
@@ -8,7 +8,7 @@ use read_fonts::collections::int_set::IntSet;
 use read_fonts::types::GlyphId;
 use skera::{Plan, SubsetFlags};
 
-use crate::{ArchiveError, ResourceId, SerializeConfig, sha256_hex};
+use crate::{ArchiveError, SerializeConfig, SerializedResourceId, sha256_hex};
 
 /// A font that has been processed (optionally subsetted and/or WOFF2-encoded) and is
 /// ready to be written into the archive.
@@ -35,23 +35,23 @@ pub(crate) struct FontWriter {
     /// Map `(Blob ID, face index)` to [`ResourceId`].
     /// When subsetting is disabled, the face in the `(Blob ID, face index)` tuple is always 0.
     /// This is because multiple faces sharing the same TTC should be keyed together.
-    id_map: HashMap<(u64, u32), ResourceId>,
+    id_map: FxHashMap<(u64, u32), SerializedResourceId>,
     fonts: Vec<FontData>,
-    glyph_ids: Vec<HashSet<u32>>,
+    glyph_ids: Vec<FxHashSet<u32>>,
 }
 
 impl FontWriter {
     pub fn new(config: SerializeConfig) -> Self {
         Self {
             config,
-            id_map: HashMap::new(),
+            id_map: FxHashMap::default(),
             fonts: Vec::new(),
             glyph_ids: Vec::new(),
         }
     }
 
     /// Register a font and return its [`ResourceId`].
-    pub fn register(&mut self, font: &FontData) -> ResourceId {
+    pub fn register(&mut self, font: &FontData) -> SerializedResourceId {
         let key = if self.config.subset_fonts {
             (font.data.id(), font.index)
         } else {
@@ -64,15 +64,15 @@ impl FontWriter {
             return id;
         }
 
-        let id = ResourceId(self.fonts.len());
+        let id = SerializedResourceId(self.fonts.len());
         self.id_map.insert(key, id);
         self.fonts.push(font.clone());
-        self.glyph_ids.push(HashSet::new());
+        self.glyph_ids.push(FxHashSet::default());
         id
     }
 
     /// Record glyph IDs used for a font resource (used for subsetting).
-    pub fn record_glyphs(&mut self, id: ResourceId, glyphs: &[anyrender::Glyph]) {
+    pub fn record_glyphs(&mut self, id: SerializedResourceId, glyphs: &[anyrender::Glyph]) {
         if self.config.subset_fonts {
             let glyph_set = &mut self.glyph_ids[id.0];
             for glyph in glyphs {

--- a/crates/anyrender_skia/Cargo.toml
+++ b/crates/anyrender_skia/Cargo.toml
@@ -22,6 +22,7 @@ peniko = { workspace = true }
 raw-window-handle = { workspace = true }
 softbuffer_window_renderer = { workspace = true, optional = true }
 pixels_window_renderer = { workspace = true, optional = true }
+rustc-hash = { workspace = true }
 skia-safe = { version = "0.91.0", features = ["gl", "pdf", "textlayout"]}
 oaty = "0.1"
 hashbrown = "0.16.0"

--- a/crates/anyrender_skia/src/lib.rs
+++ b/crates/anyrender_skia/src/lib.rs
@@ -12,5 +12,5 @@ mod opengl;
 mod vulkan;
 
 pub use image_renderer::SkiaImageRenderer;
-pub use scene::SkiaScenePainter;
+pub use scene::{SkiaRenderContext, SkiaScenePainter};
 pub use window_renderer::*;

--- a/crates/anyrender_svg/src/lib.rs
+++ b/crates/anyrender_svg/src/lib.rs
@@ -76,7 +76,7 @@ pub fn render_svg_str_with<S: PaintScene, RC: RenderContext, F: FnMut(&mut S, &u
 /// This will draw a red box over (some) unsupported elements.
 ///
 /// Any raster images embedded in the SVG are registered with `ctx` and their
-/// [`ImageResource`] handles are appended to `images`, so that you can
+/// [`ImageResource`] handles are appended to `images`, so that you the caller can
 /// later unregister them via [`RenderContext::unregister_resource`].
 pub fn render_svg_tree<S: PaintScene, RC: RenderContext>(
     ctx: &mut RC,
@@ -100,7 +100,7 @@ pub fn render_svg_tree<S: PaintScene, RC: RenderContext>(
 /// See the [module level documentation](crate#unsupported-features) for a list of some unsupported svg features
 ///
 /// Any raster images embedded in the SVG are registered with `ctx` and their
-/// [`ImageResource`] handles are appended to `images`, so that you can
+/// [`ImageResource`] handles are appended to `images`, so that the caller can
 /// later unregister them via [`RenderContext::unregister_resource`].
 pub fn render_svg_tree_with<S: PaintScene, RC: RenderContext, F: FnMut(&mut S, &usvg::Node)>(
     ctx: &mut RC,

--- a/crates/anyrender_svg/src/util.rs
+++ b/crates/anyrender_svg/src/util.rs
@@ -7,7 +7,7 @@ use peniko::color::{self, DynamicColor};
 use peniko::{Color, Fill, Mix};
 
 #[cfg(feature = "image")]
-use peniko::{Blob, ImageBrush};
+use peniko::Blob;
 
 pub(crate) fn to_affine(ts: &usvg::Transform) -> Affine {
     let usvg::Transform {
@@ -115,18 +115,16 @@ pub(crate) fn to_bez_path(path: &usvg::Path) -> BezPath {
 }
 
 #[cfg(feature = "image")]
-pub(crate) fn into_image(image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>) -> ImageBrush {
-    use peniko::ImageData;
-
+pub(crate) fn into_image(image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>) -> peniko::ImageData {
     let (width, height) = (image.width(), image.height());
     let image_data: Vec<u8> = image.into_vec();
-    ImageBrush::new(ImageData {
+    peniko::ImageData {
         data: Blob::new(std::sync::Arc::new(image_data)),
         format: peniko::ImageFormat::Rgba8,
         alpha_type: peniko::ImageAlphaType::Alpha,
         width,
         height,
-    })
+    }
 }
 
 pub(crate) fn to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Paint, Affine)> {

--- a/crates/anyrender_vello/src/lib.rs
+++ b/crates/anyrender_vello/src/lib.rs
@@ -7,7 +7,7 @@ pub mod custom_paint_source;
 
 pub use custom_paint_source::*;
 pub use image_renderer::VelloImageRenderer;
-pub use scene::VelloScenePainter;
+pub use scene::{VelloRenderContext, VelloScenePainter};
 pub use window_renderer::{VelloRendererOptions, VelloWindowRenderer};
 
 pub use wgpu;

--- a/crates/anyrender_vello_cpu/Cargo.toml
+++ b/crates/anyrender_vello_cpu/Cargo.toml
@@ -18,11 +18,6 @@ log_frame_times = [
   "pixels_window_renderer?/log_frame_times",
 ]
 
-# Caches image premultiplication, but the cache is never cleared
-# Useful for benchmarking (as we expect to eventually eliminate this cost)
-# but not recommended for use in production
-experimental_image_cache = []
-
 [dependencies]
 anyrender = { workspace = true }
 debug_timer = { workspace = true }

--- a/crates/anyrender_vello_cpu/src/image_renderer.rs
+++ b/crates/anyrender_vello_cpu/src/image_renderer.rs
@@ -1,42 +1,51 @@
-use crate::VelloCpuScenePainter;
+use crate::{VelloCpuRenderContext, VelloCpuScenePainter};
 use anyrender::ImageRenderer;
 use debug_timer::debug_timer;
-use vello_cpu::{RenderContext, RenderMode};
+use vello_cpu::{RenderContext as VelloCpuRenderCtx, RenderMode};
 
 pub struct VelloCpuImageRenderer {
-    scene: VelloCpuScenePainter,
+    render_ctx: VelloCpuRenderCtx,
 }
 
 impl ImageRenderer for VelloCpuImageRenderer {
-    type ScenePainter<'a> = VelloCpuScenePainter;
+    type ScenePainter<'a> = VelloCpuScenePainter<'a>;
+    type Context = VelloCpuRenderContext;
 
     fn new(width: u32, height: u32) -> Self {
         Self {
-            scene: VelloCpuScenePainter(RenderContext::new(width as u16, height as u16)),
+            render_ctx: VelloCpuRenderCtx::new(width as u16, height as u16),
         }
     }
 
     fn resize(&mut self, width: u32, height: u32) {
-        self.scene.0 = RenderContext::new(width as u16, height as u16);
+        self.render_ctx = VelloCpuRenderCtx::new(width as u16, height as u16);
     }
 
     fn reset(&mut self) {
-        self.scene.0.reset();
+        self.render_ctx.reset();
     }
 
-    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F, buffer: &mut [u8]) {
+    fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(
+        &mut self,
+        ctx: &mut Self::Context,
+        draw_fn: F,
+        buffer: &mut [u8],
+    ) {
         debug_timer!(timer, feature = "log_frame_times");
 
-        draw_fn(&mut self.scene);
+        {
+            let mut scene = VelloCpuScenePainter::new(ctx, &mut self.render_ctx);
+            draw_fn(&mut scene);
+        }
         timer.record_time("cmds");
 
-        self.scene.0.flush();
+        self.render_ctx.flush();
         timer.record_time("flush");
 
-        self.scene.0.render_to_buffer(
+        self.render_ctx.render_to_buffer(
             buffer,
-            self.scene.0.width(),
-            self.scene.0.height(),
+            self.render_ctx.width(),
+            self.render_ctx.height(),
             RenderMode::OptimizeSpeed,
         );
         timer.record_time("render");
@@ -46,12 +55,13 @@ impl ImageRenderer for VelloCpuImageRenderer {
 
     fn render_to_vec<F: FnOnce(&mut Self::ScenePainter<'_>)>(
         &mut self,
+        ctx: &mut Self::Context,
         draw_fn: F,
         buffer: &mut Vec<u8>,
     ) {
-        let width = self.scene.0.width();
-        let height = self.scene.0.height();
+        let width = self.render_ctx.width();
+        let height = self.render_ctx.height();
         buffer.resize(width as usize * height as usize * 4, 0);
-        self.render(draw_fn, buffer);
+        self.render(ctx, draw_fn, buffer);
     }
 }

--- a/crates/anyrender_vello_cpu/src/lib.rs
+++ b/crates/anyrender_vello_cpu/src/lib.rs
@@ -6,7 +6,7 @@ mod scene;
 mod window_renderer;
 
 pub use image_renderer::VelloCpuImageRenderer;
-pub use scene::VelloCpuScenePainter;
+pub use scene::{VelloCpuRenderContext, VelloCpuScenePainter};
 
 #[cfg(any(
     feature = "pixels_window_renderer",

--- a/crates/anyrender_vello_cpu/src/scene.rs
+++ b/crates/anyrender_vello_cpu/src/scene.rs
@@ -1,19 +1,62 @@
-use anyrender::{NormalizedCoord, Paint, PaintRef, PaintScene};
+use anyrender::{
+    ImageResource, NormalizedCoord, Paint, PaintRef, PaintScene, RenderContext, ResourceId,
+};
 use kurbo::{Affine, Rect, Shape, Stroke};
-use peniko::{BlendMode, Color, Fill, FontData, ImageBrush, StyleRef};
+use peniko::{BlendMode, Color, Fill, FontData, ImageBrush, ImageData, StyleRef};
+use std::collections::HashMap;
 use vello_cpu::{ImageSource, PaintType, Pixmap};
 
 const DEFAULT_TOLERANCE: f64 = 0.1;
 
-fn anyrender_paint_to_vello_cpu_paint<'a>(paint: PaintRef<'a>) -> PaintType {
+pub struct VelloCpuRenderContext {
+    pub(crate) resource_map: HashMap<ResourceId, ImageSource>,
+    next_resource_id: u64,
+}
+
+impl VelloCpuRenderContext {
+    pub fn new() -> Self {
+        Self {
+            resource_map: HashMap::new(),
+            next_resource_id: 0,
+        }
+    }
+}
+
+impl Default for VelloCpuRenderContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RenderContext for VelloCpuRenderContext {
+    fn register_image(&mut self, image: ImageData) -> ImageResource {
+        let resource_id = ResourceId(self.next_resource_id);
+        self.next_resource_id += 1;
+
+        let image_source = ImageSource::from_peniko_image_data(&image);
+        self.resource_map.insert(resource_id, image_source);
+
+        ImageResource {
+            id: resource_id,
+            width: image.width,
+            height: image.height,
+        }
+    }
+
+    fn unregister_resource(&mut self, id: ResourceId) {
+        self.resource_map.remove(&id);
+    }
+}
+
+fn anyrender_paint_to_vello_cpu_paint(
+    paint: PaintRef<'_>,
+    ctx: &VelloCpuRenderContext,
+) -> PaintType {
     match paint {
         Paint::Solid(alpha_color) => PaintType::Solid(alpha_color),
         Paint::Gradient(gradient) => PaintType::Gradient(gradient.clone()),
         Paint::Image(image) => PaintType::Image(ImageBrush {
-            #[cfg(not(feature = "experimental_image_cache"))]
-            image: ImageSource::from_peniko_image_data(image.image),
-            #[cfg(feature = "experimental_image_cache")]
-            image: convert_image_cached(image.image),
+            image: ctx.resource_map[&image.image.id].clone(),
             sampler: image.sampler,
         }),
         // TODO: custom paint
@@ -21,33 +64,29 @@ fn anyrender_paint_to_vello_cpu_paint<'a>(paint: PaintRef<'a>) -> PaintType {
     }
 }
 
-#[cfg(feature = "experimental_image_cache")]
-fn convert_image_cached(image: &peniko::ImageData) -> ImageSource {
-    use std::collections::HashMap;
-    use std::sync::{LazyLock, Mutex};
-    static CACHE: LazyLock<Mutex<HashMap<u64, ImageSource>>> =
-        LazyLock::new(|| Mutex::new(HashMap::new()));
-
-    let mut map = CACHE.lock().unwrap();
-    let id = image.data.id();
-    map.entry(id)
-        .or_insert_with(|| ImageSource::from_peniko_image_data(image))
-        .clone()
+pub struct VelloCpuScenePainter<'a> {
+    pub(crate) ctx: &'a VelloCpuRenderContext,
+    pub render_ctx: &'a mut vello_cpu::RenderContext,
 }
 
-pub struct VelloCpuScenePainter(pub vello_cpu::RenderContext);
+impl<'a> VelloCpuScenePainter<'a> {
+    pub fn new(
+        ctx: &'a VelloCpuRenderContext,
+        render_ctx: &'a mut vello_cpu::RenderContext,
+    ) -> Self {
+        Self { ctx, render_ctx }
+    }
 
-impl VelloCpuScenePainter {
     pub fn finish(self) -> Pixmap {
-        let mut pixmap = Pixmap::new(self.0.width(), self.0.height());
-        self.0.render_to_pixmap(&mut pixmap);
+        let mut pixmap = Pixmap::new(self.render_ctx.width(), self.render_ctx.height());
+        self.render_ctx.render_to_pixmap(&mut pixmap);
         pixmap
     }
 }
 
-impl PaintScene for VelloCpuScenePainter {
+impl PaintScene for VelloCpuScenePainter<'_> {
     fn reset(&mut self) {
-        self.0.reset();
+        self.render_ctx.reset();
     }
 
     fn push_layer(
@@ -57,8 +96,8 @@ impl PaintScene for VelloCpuScenePainter {
         transform: Affine,
         clip: &impl Shape,
     ) {
-        self.0.set_transform(transform);
-        self.0.push_layer(
+        self.render_ctx.set_transform(transform);
+        self.render_ctx.push_layer(
             Some(&clip.into_path(DEFAULT_TOLERANCE)),
             Some(blend.into()),
             Some(alpha),
@@ -68,12 +107,13 @@ impl PaintScene for VelloCpuScenePainter {
     }
 
     fn push_clip_layer(&mut self, transform: Affine, clip: &impl Shape) {
-        self.0.set_transform(transform);
-        self.0.push_clip_layer(&clip.into_path(DEFAULT_TOLERANCE));
+        self.render_ctx.set_transform(transform);
+        self.render_ctx
+            .push_clip_layer(&clip.into_path(DEFAULT_TOLERANCE));
     }
 
     fn pop_layer(&mut self) {
-        self.0.pop_layer();
+        self.render_ctx.pop_layer();
     }
 
     fn stroke<'a>(
@@ -84,13 +124,14 @@ impl PaintScene for VelloCpuScenePainter {
         brush_transform: Option<Affine>,
         shape: &impl Shape,
     ) {
-        self.0.set_transform(transform);
-        self.0.set_stroke(style.clone());
-        self.0
-            .set_paint(anyrender_paint_to_vello_cpu_paint(paint.into()));
-        self.0
+        self.render_ctx.set_transform(transform);
+        self.render_ctx.set_stroke(style.clone());
+        self.render_ctx
+            .set_paint(anyrender_paint_to_vello_cpu_paint(paint.into(), self.ctx));
+        self.render_ctx
             .set_paint_transform(brush_transform.unwrap_or(Affine::IDENTITY));
-        self.0.stroke_path(&shape.into_path(DEFAULT_TOLERANCE));
+        self.render_ctx
+            .stroke_path(&shape.into_path(DEFAULT_TOLERANCE));
     }
 
     fn fill<'a>(
@@ -101,13 +142,14 @@ impl PaintScene for VelloCpuScenePainter {
         brush_transform: Option<Affine>,
         shape: &impl Shape,
     ) {
-        self.0.set_transform(transform);
-        self.0.set_fill_rule(style);
-        self.0
-            .set_paint(anyrender_paint_to_vello_cpu_paint(paint.into()));
-        self.0
+        self.render_ctx.set_transform(transform);
+        self.render_ctx.set_fill_rule(style);
+        self.render_ctx
+            .set_paint(anyrender_paint_to_vello_cpu_paint(paint.into(), self.ctx));
+        self.render_ctx
             .set_paint_transform(brush_transform.unwrap_or(Affine::IDENTITY));
-        self.0.fill_path(&shape.into_path(DEFAULT_TOLERANCE));
+        self.render_ctx
+            .fill_path(&shape.into_path(DEFAULT_TOLERANCE));
     }
 
     fn draw_glyphs<'a, 's: 'a>(
@@ -123,9 +165,9 @@ impl PaintScene for VelloCpuScenePainter {
         glyph_transform: Option<Affine>,
         glyphs: impl Iterator<Item = anyrender::Glyph>,
     ) {
-        self.0.set_transform(transform);
-        self.0
-            .set_paint(anyrender_paint_to_vello_cpu_paint(paint.into()));
+        self.render_ctx.set_transform(transform);
+        self.render_ctx
+            .set_paint(anyrender_paint_to_vello_cpu_paint(paint.into(), self.ctx));
 
         fn into_vello_cpu_glyph(g: anyrender::Glyph) -> vello_cpu::Glyph {
             vello_cpu::Glyph {
@@ -138,8 +180,8 @@ impl PaintScene for VelloCpuScenePainter {
         let style: StyleRef<'a> = style.into();
         match style {
             StyleRef::Fill(fill) => {
-                self.0.set_fill_rule(fill);
-                self.0
+                self.render_ctx.set_fill_rule(fill);
+                self.render_ctx
                     .glyph_run(font)
                     .font_size(font_size)
                     .hint(hint)
@@ -148,8 +190,8 @@ impl PaintScene for VelloCpuScenePainter {
                     .fill_glyphs(glyphs.map(into_vello_cpu_glyph));
             }
             StyleRef::Stroke(stroke) => {
-                self.0.set_stroke(stroke.clone());
-                self.0
+                self.render_ctx.set_stroke(stroke.clone());
+                self.render_ctx
                     .glyph_run(font)
                     .font_size(font_size)
                     .hint(hint)
@@ -167,9 +209,9 @@ impl PaintScene for VelloCpuScenePainter {
         radius: f64,
         std_dev: f64,
     ) {
-        self.0.set_transform(transform);
-        self.0.set_paint(PaintType::Solid(color));
-        self.0
+        self.render_ctx.set_transform(transform);
+        self.render_ctx.set_paint(PaintType::Solid(color));
+        self.render_ctx
             .fill_blurred_rounded_rect(&rect, radius as f32, std_dev as f32);
     }
 }

--- a/crates/anyrender_vello_hybrid/src/lib.rs
+++ b/crates/anyrender_vello_hybrid/src/lib.rs
@@ -6,8 +6,7 @@ mod scene;
 mod webgl_scene;
 mod window_renderer;
 
-pub use scene::ImageManager;
-pub use scene::VelloHybridScenePainter;
+pub use scene::{VelloHybridRenderContext, VelloHybridScenePainter};
 #[cfg(all(target_arch = "wasm32", feature = "webgl"))]
 pub use webgl_scene::*;
-pub use window_renderer::*;
+pub use window_renderer::{VelloHybridRendererOptions, VelloHybridWindowRenderer};

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -47,6 +47,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         = <Renderer as ImageRenderer>::ScenePainter<'a>
     where
         Renderer: 'a;
+    type Context = Renderer::Context;
 
     fn is_active(&self) -> bool {
         matches!(self.render_state, RenderState::Active(_))
@@ -86,7 +87,11 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         };
     }
 
-    fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(&mut self, draw_fn: F) {
+    fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(
+        &mut self,
+        ctx: &mut Self::Context,
+        draw_fn: F,
+    ) {
         let RenderState::Active(state) = &mut self.render_state else {
             return;
         };
@@ -94,7 +99,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         debug_timer!(timer, feature = "log_frame_times");
 
         // Paint
-        self.renderer.render(draw_fn, state.pixels.frame_mut());
+        self.renderer.render(ctx, draw_fn, state.pixels.frame_mut());
         timer.record_time("render");
 
         state.pixels.render().unwrap();

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -49,6 +49,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         = Renderer::ScenePainter<'a>
     where
         Self: 'a;
+    type Context = Renderer::Context;
 
     fn is_active(&self) -> bool {
         matches!(self.render_state, RenderState::Active(_))
@@ -83,7 +84,11 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         };
     }
 
-    fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(&mut self, draw_fn: F) {
+    fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(
+        &mut self,
+        ctx: &mut Self::Context,
+        draw_fn: F,
+    ) {
         let RenderState::Active(state) = &mut self.render_state else {
             return;
         };
@@ -96,7 +101,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         timer.record_time("buffer_mut");
 
         // Paint
-        self.renderer.render_to_vec(draw_fn, &mut self.buffer);
+        self.renderer.render_to_vec(ctx, draw_fn, &mut self.buffer);
         timer.record_time("render");
 
         let out = surface_buffer.as_mut();

--- a/examples/bunnymark/Cargo.toml
+++ b/examples/bunnymark/Cargo.toml
@@ -13,7 +13,7 @@ image = { workspace = true, features = ["png"] }
 anyrender = { workspace = true }
 anyrender_vello = { workspace = true, features = ["log_frame_times"] }
 anyrender_vello_hybrid = { workspace = true, features = ["log_frame_times"] }
-anyrender_vello_cpu = { workspace = true, features = ["pixels_window_renderer", "multithreading", "experimental_image_cache", "log_frame_times"] }
+anyrender_vello_cpu = { workspace = true, features = ["pixels_window_renderer", "multithreading", "log_frame_times"] }
 anyrender_skia = { workspace = true, features = ["log_frame_times"] }
 pixels_window_renderer = { workspace = true }
 fastrand = "2.3"

--- a/examples/bunnymark/src/bunny.rs
+++ b/examples/bunnymark/src/bunny.rs
@@ -131,7 +131,7 @@ impl BunnyManager {
         for bunny in &self.bunnies {
             let pos = bunny.position();
             scene.draw_image(
-                bunny_image.clone(),
+                *bunny_image,
                 Affine::translate(pos).then_scale(scale_factor),
             );
         }


### PR DESCRIPTION
Refactors `RenderContext` from being owned by renderer internals into a standalone, consumer-owned object passed by reference. This makes resource (image) lifetime management explicit and removes the burden of managing resource maps and ID counters from consumers.

Previously, Vello Hybrid would leak images. This changes enables consumers for explicitly managing image resource lifecycle.

## Design Decisions

### Deferred vs Eager Image Upload

There is a tension with the initial implementation and the introduction of `RenderContext`. The `anyrender_svg` crate was uploading images to the GPU as soon as it encountered an image node. It is likely preferential to bulk/batch upload images to the GPU rather than creating a per-image command encoder.

For now, we've stuck with the eager strategy, but I imagine there's an opportunity here to iterate the design to support deferred upload. I think this is a step in the right direction, regardless. 

It should be noted that the current design supports both eager and deferred upload. To defer upload, simply `register_image` in Vello Hybrid prior to rendering some scene.