### PR TITLE
Fix EGL_BAD_MATCH crash on X11 by pre-picking a GL-compatible visual

### DIFF
--- a/crates/anyrender_skia/src/lib.rs
+++ b/crates/anyrender_skia/src/lib.rs
@@ -14,3 +14,6 @@ mod vulkan;
 pub use image_renderer::SkiaImageRenderer;
 pub use scene::{SkiaSceneCache, SkiaScenePainter};
 pub use window_renderer::*;
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+pub use opengl::pick_x11_gl_visual;

--- a/crates/anyrender_skia/src/lib.rs
+++ b/crates/anyrender_skia/src/lib.rs
@@ -15,5 +15,8 @@ pub use image_renderer::SkiaImageRenderer;
 pub use scene::{SkiaSceneCache, SkiaScenePainter};
 pub use window_renderer::*;
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
 pub use opengl::pick_x11_gl_visual;

--- a/crates/anyrender_skia/src/opengl.rs
+++ b/crates/anyrender_skia/src/opengl.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::{ffi::CString, num::NonZeroU32, sync::Arc};
 
 use glutin::config::Config;
@@ -35,7 +37,7 @@ fn build_gl_display(raw_display_handle: RawDisplayHandle, _raw_window: Option<Ra
     }
 }
 
-fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Config {
+fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Option<Config> {
     let mut template = ConfigTemplateBuilder::new().with_transparency(true);
     if let Some(rwh) = raw_window {
         template = template.compatible_with_native_window(rwh);
@@ -44,7 +46,7 @@ fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Con
     unsafe {
         display
             .find_configs(template)
-            .unwrap()
+            .ok()?
             .reduce(|accum, config| {
                 let transparency_check = config.supports_transparency().unwrap_or(false)
                     & !accum.supports_transparency().unwrap_or(false);
@@ -55,8 +57,42 @@ fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Con
                     accum
                 }
             })
-            .expect("no GL config found for display")
     }
+}
+
+/// Cache of glutin `Display`s keyed by the raw X display/connection pointer, to avoid
+/// double-initializing EGL for the same X server connection (once in `pick_x11_gl_visual`
+/// and again in `OpenGLBackend::new`).
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+fn display_cache() -> &'static Mutex<HashMap<usize, Display>> {
+    static CACHE: OnceLock<Mutex<HashMap<usize, Display>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+fn display_cache_key(raw_display_handle: RawDisplayHandle) -> Option<usize> {
+    match raw_display_handle {
+        RawDisplayHandle::Xlib(h) => h.display.map(|p| p.as_ptr() as usize),
+        RawDisplayHandle::Xcb(h) => h.connection.map(|p| p.as_ptr() as usize),
+        _ => None,
+    }
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+fn get_or_build_gl_display(
+    raw_display_handle: RawDisplayHandle,
+    raw_window: Option<RawWindowHandle>,
+) -> Display {
+    if let Some(key) = display_cache_key(raw_display_handle) {
+        let mut cache = display_cache().lock().unwrap();
+        if let Some(d) = cache.get(&key) {
+            return d.clone();
+        }
+        let display = build_gl_display(raw_display_handle, raw_window);
+        cache.insert(key, display.clone());
+        return display;
+    }
+    build_gl_display(raw_display_handle, raw_window)
 }
 
 /// Pick an X11 visual ID compatible with the OpenGL backend used by [`SkiaWindowRenderer`].
@@ -65,8 +101,9 @@ fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Con
 /// before creating the window. This avoids `EGL_BAD_MATCH` at surface creation, which happens
 /// when winit's default visual doesn't match any EGL config.
 ///
-/// Returns `None` on non-X11 displays (Wayland, macOS, Windows) or if the platform's EGL
-/// implementation doesn't expose an X11 visual ID for the picked config.
+/// Returns `None` on non-Xlib/Xcb display handles, if no compatible EGL config can be
+/// found, or if the platform's EGL implementation doesn't expose an X11 visual ID for the
+/// picked config.
 ///
 /// [`WindowAttributesExtX11::with_x11_visual`]: https://docs.rs/winit/latest/winit/platform/x11/trait.WindowAttributesExtX11.html#tymethod.with_x11_visual
 #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
@@ -74,8 +111,8 @@ pub fn pick_x11_gl_visual(raw_display_handle: RawDisplayHandle) -> Option<u32> {
     if !matches!(raw_display_handle, RawDisplayHandle::Xlib(_) | RawDisplayHandle::Xcb(_)) {
         return None;
     }
-    let display = build_gl_display(raw_display_handle, None);
-    let config = pick_gl_config(&display, None);
+    let display = get_or_build_gl_display(raw_display_handle, None);
+    let config = pick_gl_config(&display, None)?;
     use glutin::platform::x11::X11GlConfigExt;
     config.x11_visual().map(|v| v.visual_id() as u32)
 }
@@ -97,8 +134,13 @@ impl OpenGLBackend {
         let raw_display_handle = window.display_handle().unwrap().as_raw();
         let raw_window_handle = window.window_handle().unwrap().as_raw();
 
+        #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+        let gl_display = get_or_build_gl_display(raw_display_handle, Some(raw_window_handle));
+        #[cfg(not(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android")))))]
         let gl_display = build_gl_display(raw_display_handle, Some(raw_window_handle));
-        let gl_config = pick_gl_config(&gl_display, Some(raw_window_handle));
+
+        let gl_config = pick_gl_config(&gl_display, Some(raw_window_handle))
+            .expect("no GL config found for display");
 
         let gl_context_attrs = ContextAttributesBuilder::new().build(Some(raw_window_handle));
         let gl_surface_attrs = SurfaceAttributesBuilder::<WindowSurface>::new().build(

--- a/crates/anyrender_skia/src/opengl.rs
+++ b/crates/anyrender_skia/src/opengl.rs
@@ -22,7 +22,10 @@ use skia_safe::{
 
 use crate::window_renderer::SkiaBackend;
 
-fn build_gl_display(raw_display_handle: RawDisplayHandle, _raw_window: Option<RawWindowHandle>) -> Display {
+fn build_gl_display(
+    raw_display_handle: RawDisplayHandle,
+    _raw_window: Option<RawWindowHandle>,
+) -> Display {
     unsafe {
         Display::new(
             raw_display_handle,
@@ -63,13 +66,19 @@ fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Opt
 /// Cache of glutin `Display`s keyed by the raw X display/connection pointer, to avoid
 /// double-initializing EGL for the same X server connection (once in `pick_x11_gl_visual`
 /// and again in `OpenGLBackend::new`).
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
 fn display_cache() -> &'static Mutex<HashMap<usize, Display>> {
     static CACHE: OnceLock<Mutex<HashMap<usize, Display>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
 fn display_cache_key(raw_display_handle: RawDisplayHandle) -> Option<usize> {
     match raw_display_handle {
         RawDisplayHandle::Xlib(h) => h.display.map(|p| p.as_ptr() as usize),
@@ -78,7 +87,10 @@ fn display_cache_key(raw_display_handle: RawDisplayHandle) -> Option<usize> {
     }
 }
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
 fn get_or_build_gl_display(
     raw_display_handle: RawDisplayHandle,
     raw_window: Option<RawWindowHandle>,
@@ -105,10 +117,17 @@ fn get_or_build_gl_display(
 /// found, or if the platform's EGL implementation doesn't expose an X11 visual ID for the
 /// picked config.
 ///
+/// [`SkiaWindowRenderer`]: crate::SkiaWindowRenderer
 /// [`WindowAttributesExtX11::with_x11_visual`]: https://docs.rs/winit/latest/winit/platform/x11/trait.WindowAttributesExtX11.html#tymethod.with_x11_visual
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
 pub fn pick_x11_gl_visual(raw_display_handle: RawDisplayHandle) -> Option<u32> {
-    if !matches!(raw_display_handle, RawDisplayHandle::Xlib(_) | RawDisplayHandle::Xcb(_)) {
+    if !matches!(
+        raw_display_handle,
+        RawDisplayHandle::Xlib(_) | RawDisplayHandle::Xcb(_)
+    ) {
         return None;
     }
     let display = get_or_build_gl_display(raw_display_handle, None);
@@ -134,9 +153,15 @@ impl OpenGLBackend {
         let raw_display_handle = window.display_handle().unwrap().as_raw();
         let raw_window_handle = window.window_handle().unwrap().as_raw();
 
-        #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+        #[cfg(all(
+            unix,
+            not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+        ))]
         let gl_display = get_or_build_gl_display(raw_display_handle, Some(raw_window_handle));
-        #[cfg(not(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android")))))]
+        #[cfg(not(all(
+            unix,
+            not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+        )))]
         let gl_display = build_gl_display(raw_display_handle, Some(raw_window_handle));
 
         let gl_config = pick_gl_config(&gl_display, Some(raw_window_handle))

--- a/crates/anyrender_skia/src/opengl.rs
+++ b/crates/anyrender_skia/src/opengl.rs
@@ -1,5 +1,6 @@
 use std::{ffi::CString, num::NonZeroU32, sync::Arc};
 
+use glutin::config::Config;
 use glutin::display::DisplayApiPreference;
 use glutin::{
     config::{ConfigTemplateBuilder, GetGlConfig, GlConfig},
@@ -8,6 +9,7 @@ use glutin::{
     prelude::{GlDisplay, NotCurrentGlContext, PossiblyCurrentGlContext},
     surface::{GlSurface, SurfaceAttributesBuilder, WindowSurface},
 };
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use skia_safe::{
     Surface,
     gpu::{
@@ -17,6 +19,66 @@ use skia_safe::{
 };
 
 use crate::window_renderer::SkiaBackend;
+
+fn build_gl_display(raw_display_handle: RawDisplayHandle, _raw_window: Option<RawWindowHandle>) -> Display {
+    unsafe {
+        Display::new(
+            raw_display_handle,
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            DisplayApiPreference::Cgl,
+            #[cfg(target_os = "windows")]
+            DisplayApiPreference::Wgl(_raw_window),
+            #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))]
+            DisplayApiPreference::Egl,
+        )
+        .unwrap()
+    }
+}
+
+fn pick_gl_config(display: &Display, raw_window: Option<RawWindowHandle>) -> Config {
+    let mut template = ConfigTemplateBuilder::new().with_transparency(true);
+    if let Some(rwh) = raw_window {
+        template = template.compatible_with_native_window(rwh);
+    }
+    let template = template.build();
+    unsafe {
+        display
+            .find_configs(template)
+            .unwrap()
+            .reduce(|accum, config| {
+                let transparency_check = config.supports_transparency().unwrap_or(false)
+                    & !accum.supports_transparency().unwrap_or(false);
+
+                if transparency_check || config.num_samples() < accum.num_samples() {
+                    config
+                } else {
+                    accum
+                }
+            })
+            .expect("no GL config found for display")
+    }
+}
+
+/// Pick an X11 visual ID compatible with the OpenGL backend used by [`SkiaWindowRenderer`].
+///
+/// Apply the returned visual to the winit window with [`WindowAttributesExtX11::with_x11_visual`]
+/// before creating the window. This avoids `EGL_BAD_MATCH` at surface creation, which happens
+/// when winit's default visual doesn't match any EGL config.
+///
+/// Returns `None` on non-X11 displays (Wayland, macOS, Windows) or if the platform's EGL
+/// implementation doesn't expose an X11 visual ID for the picked config.
+///
+/// [`WindowAttributesExtX11::with_x11_visual`]: https://docs.rs/winit/latest/winit/platform/x11/trait.WindowAttributesExtX11.html#tymethod.with_x11_visual
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+pub fn pick_x11_gl_visual(raw_display_handle: RawDisplayHandle) -> Option<u32> {
+    if !matches!(raw_display_handle, RawDisplayHandle::Xlib(_) | RawDisplayHandle::Xcb(_)) {
+        return None;
+    }
+    let display = build_gl_display(raw_display_handle, None);
+    let config = pick_gl_config(&display, None);
+    use glutin::platform::x11::X11GlConfigExt;
+    config.x11_visual().map(|v| v.visual_id() as u32)
+}
 
 pub(crate) struct OpenGLBackend {
     surface: Option<Surface>,
@@ -35,36 +97,8 @@ impl OpenGLBackend {
         let raw_display_handle = window.display_handle().unwrap().as_raw();
         let raw_window_handle = window.window_handle().unwrap().as_raw();
 
-        let gl_display = unsafe {
-            Display::new(
-                raw_display_handle,
-                #[cfg(any(target_os = "macos", target_os = "ios"))]
-                DisplayApiPreference::Cgl,
-                #[cfg(target_os = "windows")]
-                DisplayApiPreference::Wgl(Some(raw_window_handle.clone())),
-                #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))]
-                DisplayApiPreference::Egl,
-            )
-            .unwrap()
-        };
-
-        let gl_config_template = ConfigTemplateBuilder::new().with_transparency(true).build();
-        let gl_config = unsafe {
-            gl_display
-                .find_configs(gl_config_template)
-                .unwrap()
-                .reduce(|accum, config| {
-                    let transparency_check = config.supports_transparency().unwrap_or(false)
-                        & !accum.supports_transparency().unwrap_or(false);
-
-                    if transparency_check || config.num_samples() < accum.num_samples() {
-                        config
-                    } else {
-                        accum
-                    }
-                })
-                .unwrap()
-        };
+        let gl_display = build_gl_display(raw_display_handle, Some(raw_window_handle));
+        let gl_config = pick_gl_config(&gl_display, Some(raw_window_handle));
 
         let gl_context_attrs = ContextAttributesBuilder::new().build(Some(raw_window_handle));
         let gl_surface_attrs = SurfaceAttributesBuilder::<WindowSurface>::new().build(

--- a/examples/bunnymark/src/main.rs
+++ b/examples/bunnymark/src/main.rs
@@ -1,5 +1,8 @@
 use anyrender::{PaintScene, WindowRenderer};
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
 use anyrender_skia::pick_x11_gl_visual;
 use anyrender_skia::{SkiaImageRenderer, SkiaWindowRenderer};
 use anyrender_vello::VelloWindowRenderer;
@@ -149,14 +152,17 @@ impl App {
             // On X11, pre-pick a visual that's compatible with the OpenGL backend's EGL
             // configs. winit otherwise inherits the root window's visual via COPY_FROM_PARENT,
             // which may have no matching EGL config and causes EGL_BAD_MATCH at surface creation.
-            #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+            #[cfg(all(
+                unix,
+                not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+            ))]
             {
                 use winit::platform::x11::WindowAttributesExtX11;
                 use winit::raw_window_handle::HasDisplayHandle;
-                if let Ok(display_handle) = event_loop.display_handle() {
-                    if let Some(visual_id) = pick_x11_gl_visual(display_handle.as_raw()) {
-                        attr = attr.with_x11_visual(visual_id);
-                    }
+                if let Ok(display_handle) = event_loop.display_handle()
+                    && let Some(visual_id) = pick_x11_gl_visual(display_handle.as_raw())
+                {
+                    attr = attr.with_x11_visual(visual_id);
                 }
             }
 

--- a/examples/bunnymark/src/main.rs
+++ b/examples/bunnymark/src/main.rs
@@ -1,4 +1,6 @@
 use anyrender::{PaintScene, WindowRenderer};
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+use anyrender_skia::pick_x11_gl_visual;
 use anyrender_skia::{SkiaImageRenderer, SkiaWindowRenderer};
 use anyrender_vello::VelloWindowRenderer;
 use anyrender_vello_cpu::VelloCpuWindowRenderer;
@@ -134,7 +136,7 @@ impl App {
             RenderState::Suspended(cached_window) => cached_window.clone(),
         };
         let window = window.take().unwrap_or_else(|| {
-            let attr = Window::default_attributes()
+            let mut attr = Window::default_attributes()
                 .with_inner_size(winit::dpi::LogicalSize::new(
                     self.logical_width,
                     self.logical_height,
@@ -143,6 +145,21 @@ impl App {
                 .with_title("anyrender + winit demo")
                 .with_visible(true)
                 .with_active(true);
+
+            // On X11, pre-pick a visual that's compatible with the OpenGL backend's EGL
+            // configs. winit otherwise inherits the root window's visual via COPY_FROM_PARENT,
+            // which may have no matching EGL config and causes EGL_BAD_MATCH at surface creation.
+            #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+            {
+                use winit::platform::x11::WindowAttributesExtX11;
+                use winit::raw_window_handle::HasDisplayHandle;
+                if let Ok(display_handle) = event_loop.display_handle() {
+                    if let Some(visual_id) = pick_x11_gl_visual(display_handle.as_raw()) {
+                        attr = attr.with_x11_visual(visual_id);
+                    }
+                }
+            }
+
             Arc::new(event_loop.create_window(attr).unwrap())
         });
         self.scale_factor = window.scale_factor();

--- a/examples/player/src/main.rs
+++ b/examples/player/src/main.rs
@@ -1,8 +1,11 @@
 use anyrender::{NullWindowRenderer, PaintScene, Scene, WindowRenderer};
 use anyrender_serialize::SceneArchive;
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
-use anyrender_skia::pick_x11_gl_visual;
 use anyrender_skia::SkiaWindowRenderer;
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+))]
+use anyrender_skia::pick_x11_gl_visual;
 use anyrender_vello::VelloWindowRenderer;
 use anyrender_vello_cpu::{PixelsWindowRenderer, SoftbufferWindowRenderer, VelloCpuImageRenderer};
 use anyrender_vello_hybrid::VelloHybridWindowRenderer;
@@ -143,14 +146,17 @@ impl App {
             // On X11, pre-pick a visual that's compatible with the OpenGL backend's EGL
             // configs. winit otherwise inherits the root window's visual via COPY_FROM_PARENT,
             // which may have no matching EGL config and causes EGL_BAD_MATCH at surface creation.
-            #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+            #[cfg(all(
+                unix,
+                not(any(target_os = "macos", target_os = "ios", target_os = "android"))
+            ))]
             {
                 use winit::platform::x11::WindowAttributesExtX11;
                 use winit::raw_window_handle::HasDisplayHandle;
-                if let Ok(display_handle) = event_loop.display_handle() {
-                    if let Some(visual_id) = pick_x11_gl_visual(display_handle.as_raw()) {
-                        attr = attr.with_x11_visual(visual_id);
-                    }
+                if let Ok(display_handle) = event_loop.display_handle()
+                    && let Some(visual_id) = pick_x11_gl_visual(display_handle.as_raw())
+                {
+                    attr = attr.with_x11_visual(visual_id);
                 }
             }
 

--- a/examples/player/src/main.rs
+++ b/examples/player/src/main.rs
@@ -1,5 +1,7 @@
 use anyrender::{NullWindowRenderer, PaintScene, Scene, WindowRenderer};
 use anyrender_serialize::SceneArchive;
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+use anyrender_skia::pick_x11_gl_visual;
 use anyrender_skia::SkiaWindowRenderer;
 use anyrender_vello::VelloWindowRenderer;
 use anyrender_vello_cpu::{PixelsWindowRenderer, SoftbufferWindowRenderer, VelloCpuImageRenderer};
@@ -131,12 +133,27 @@ impl App {
             RenderState::Suspended(cached_window) => cached_window.clone(),
         };
         let window = window.take().unwrap_or_else(|| {
-            let attr = Window::default_attributes()
+            let mut attr = Window::default_attributes()
                 .with_inner_size(winit::dpi::LogicalSize::new(self.width, self.height))
                 .with_resizable(true)
                 .with_title("anyrender + winit demo")
                 .with_visible(true)
                 .with_active(true);
+
+            // On X11, pre-pick a visual that's compatible with the OpenGL backend's EGL
+            // configs. winit otherwise inherits the root window's visual via COPY_FROM_PARENT,
+            // which may have no matching EGL config and causes EGL_BAD_MATCH at surface creation.
+            #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))]
+            {
+                use winit::platform::x11::WindowAttributesExtX11;
+                use winit::raw_window_handle::HasDisplayHandle;
+                if let Ok(display_handle) = event_loop.display_handle() {
+                    if let Some(visual_id) = pick_x11_gl_visual(display_handle.as_raw()) {
+                        attr = attr.with_x11_visual(visual_id);
+                    }
+                }
+            }
+
             Arc::new(event_loop.create_window(attr).unwrap())
         });
 


### PR DESCRIPTION
On Linux/X11, winit creates windows with `COPY_FROM_PARENT` for the visual, which may not have any matching EGL FBConfig and causes `SkiaWindowRenderer`'s OpenGL backend to panic with `EGL_BAD_MATCH` at `eglCreateWindowSurface` (reproduced on NVIDIA + X11). This PR adds a public `anyrender_skia::pick_x11_gl_visual` helper that queries a compatible visual from the EGL configs so callers can apply it via `WindowAttributesExtX11::with_x11_visual` before window creation, and updates the `bunnymark` and `player` examples to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)