### PR TITLE
Make `WindowRenderer::resume` async (w/callback) for wasm-friendly wgpu init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,11 +222,13 @@ version = "0.8.0"
 dependencies = [
  "anyrender",
  "debug_timer",
+ "futures-channel",
  "kurbo",
  "peniko",
  "pollster",
  "rustc-hash 2.1.2",
  "vello",
+ "wasm-bindgen-futures",
  "wgpu 28.0.0",
  "wgpu_context",
 ]
@@ -250,12 +252,14 @@ version = "0.3.0"
 dependencies = [
  "anyrender",
  "debug_timer",
+ "futures-channel",
  "kurbo",
  "peniko",
  "pollster",
  "rustc-hash 2.1.2",
  "vello_common",
  "vello_hybrid",
+ "wasm-bindgen-futures",
  "wgpu 28.0.0",
  "wgpu_context",
 ]
@@ -1194,6 +1198,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,9 @@ debug_timer = "0.1.1"
 rustc-hash = "2"
 futures-util = "0.3.31"
 futures-intrusive = "0.5.0"
+futures-channel = "0.3"
 pollster = "0.4"
+wasm-bindgen-futures = "0.4"
 
 # Dev-dependencies
 winit = { version = "0.30.2", features = ["rwh_06"] }

--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -129,14 +129,21 @@ pub trait WindowRenderer: RenderContext {
     /// active and ready to render. Idempotent on already-active renderers; returns
     /// `false` if a pending init has not yet produced a result.
     ///
-    /// The default implementation returns `true` for backends whose `resume` finishes
-    /// synchronously inline.
-    fn complete_resume(&mut self) -> bool {
-        true
-    }
+    /// Backends whose `resume` finishes synchronously inline should return `true`
+    /// directly. There is intentionally no default: forgetting to override this on
+    /// an async-init backend would silently no-op rendering.
+    fn complete_resume(&mut self) -> bool;
 
     fn suspend(&mut self);
     fn is_active(&self) -> bool;
+
+    /// Returns `true` while an asynchronous resume is in flight (after `resume`
+    /// but before `complete_resume` has succeeded). Defaults to `false` for
+    /// backends with synchronous initialization.
+    fn is_pending(&self) -> bool {
+        false
+    }
+
     fn set_size(&mut self, width: u32, height: u32);
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F);
 }

--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -21,6 +21,15 @@
 //!
 //! The [anyrender_svg](https://docs.rs/anyrender_svg) crate allows SVGs to be rendered using AnyRender
 //!
+//! ### WASM support
+//!
+//! Wgpu adapter/device/surface initialization is fundamentally async on the web. To avoid
+//! deadlocking the JS event loop, [`WindowRenderer::resume`] takes an `on_ready` callback:
+//! GPU backends spawn the init on `wasm_bindgen_futures::spawn_local` and invoke the callback
+//! once the surface is live. The embedder then calls [`WindowRenderer::complete_resume`] to
+//! transition the renderer to the active state. On native targets the same code path runs
+//! inline (`pollster::block_on` on the GPU backends), so callers see no behavioural difference.
+//!
 //! ### Backends
 //!
 //! Currently existing backends are:
@@ -102,7 +111,30 @@ pub trait WindowRenderer: RenderContext {
     type ScenePainter<'a>: PaintScene
     where
         Self: 'a;
-    fn resume(&mut self, window: Arc<dyn WindowHandle>, width: u32, height: u32);
+
+    /// Begin resuming the renderer. `on_ready` fires when initialization completes —
+    /// synchronously inside `resume` on native, asynchronously (via
+    /// `wasm_bindgen_futures::spawn_local`) on `wasm32-unknown-unknown`. After it
+    /// fires, the embedder must call [`complete_resume`](Self::complete_resume) to
+    /// transition the renderer to the active state.
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        window: Arc<dyn WindowHandle>,
+        width: u32,
+        height: u32,
+        on_ready: F,
+    );
+
+    /// Finalize a previously-initiated resume. Returns `true` once the renderer is
+    /// active and ready to render. Idempotent on already-active renderers; returns
+    /// `false` if a pending init has not yet produced a result.
+    ///
+    /// The default implementation returns `true` for backends whose `resume` finishes
+    /// synchronously inline.
+    fn complete_resume(&mut self) -> bool {
+        true
+    }
+
     fn suspend(&mut self);
     fn is_active(&self) -> bool;
     fn set_size(&mut self, width: u32, height: u32);

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -32,6 +32,10 @@ impl WindowRenderer for NullWindowRenderer {
         on_ready();
     }
 
+    fn complete_resume(&mut self) -> bool {
+        true
+    }
+
     fn suspend(&mut self) {
         self.is_active = false
     }

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -21,8 +21,15 @@ impl WindowRenderer for NullWindowRenderer {
     where
         Self: 'a;
 
-    fn resume(&mut self, _window: Arc<dyn WindowHandle>, _width: u32, _height: u32) {
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        _window: Arc<dyn WindowHandle>,
+        _width: u32,
+        _height: u32,
+        on_ready: F,
+    ) {
         self.is_active = true;
+        on_ready();
     }
 
     fn suspend(&mut self) {

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -73,6 +73,10 @@ impl WindowRenderer for SkiaWindowRenderer {
         on_ready();
     }
 
+    fn complete_resume(&mut self) -> bool {
+        true
+    }
+
     fn suspend(&mut self) {
         self.render_state = RenderState::Suspended;
     }

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -50,7 +50,13 @@ impl WindowRenderer for SkiaWindowRenderer {
     where
         Self: 'a;
 
-    fn resume(&mut self, window: Arc<dyn anyrender::WindowHandle>, width: u32, height: u32) {
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        window: Arc<dyn anyrender::WindowHandle>,
+        width: u32,
+        height: u32,
+        on_ready: F,
+    ) {
         graphics::set_font_cache_count_limit(100);
         graphics::set_typeface_cache_count_limit(100);
         graphics::set_resource_cache_total_bytes_limit(10485760);
@@ -63,7 +69,8 @@ impl WindowRenderer for SkiaWindowRenderer {
         self.render_state = RenderState::Active(Box::new(ActiveRenderState {
             backend: Box::new(backend),
             scene_cache: SkiaSceneCache::default(),
-        }))
+        }));
+        on_ready();
     }
 
     fn suspend(&mut self) {

--- a/crates/anyrender_vello/Cargo.toml
+++ b/crates/anyrender_vello/Cargo.toml
@@ -20,5 +20,11 @@ kurbo = { workspace = true }
 peniko = { workspace = true }
 vello = { workspace = true }
 wgpu = { workspace = true }
-pollster = { workspace = true }
 rustc-hash = { workspace = true }
+futures-channel = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pollster = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { workspace = true }

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -40,22 +40,16 @@ struct ActiveRenderState {
 /// Result of a successful asynchronous resume; both the active state and the
 /// `WGPUContext` are returned so the renderer can reclaim the context.
 struct InitOutput {
-    wgpu_context: WGPUContext,
     active: ActiveRenderState,
 }
 
 #[allow(clippy::large_enum_variant)]
 enum RenderState {
-    Suspended {
-        wgpu_context: WGPUContext,
-    },
+    Suspended,
     Pending {
         receiver: oneshot::Receiver<InitOutput>,
     },
-    Active {
-        wgpu_context: WGPUContext,
-        active: ActiveRenderState,
-    },
+    Active(ActiveRenderState),
 }
 
 #[derive(Clone)]
@@ -83,6 +77,7 @@ pub struct VelloWindowRenderer {
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
 
+    wgpu_context: WGPUContext,
     scene: VelloScene,
     config: VelloRendererOptions,
 
@@ -96,9 +91,9 @@ impl VelloWindowRenderer {
     }
 
     pub fn with_options(config: VelloRendererOptions) -> Self {
-        let wgpu_context = build_wgpu_context(&config);
         Self {
-            render_state: RenderState::Suspended { wgpu_context },
+            render_state: RenderState::Suspended,
+            wgpu_context: build_wgpu_context(&config),
             config,
             window_handle: None,
             scene: VelloScene::new(),
@@ -108,7 +103,7 @@ impl VelloWindowRenderer {
 
     pub fn current_device_handle(&self) -> Option<&DeviceHandle> {
         match &self.render_state {
-            RenderState::Active { active, .. } => Some(&active.render_surface.device_handle),
+            RenderState::Active(active) => Some(&active.render_surface.device_handle),
             _ => None,
         }
     }
@@ -119,7 +114,7 @@ impl RenderContext for VelloWindowRenderer {
         &mut self,
         resource: Box<dyn std::any::Any>,
     ) -> Result<ResourceId, anyrender::RegisterResourceError> {
-        let RenderState::Active { active, .. } = &mut self.render_state else {
+        let RenderState::Active(active) = &mut self.render_state else {
             return Err(RegisterResourceErrorKind::NotActive.into());
         };
 
@@ -134,7 +129,7 @@ impl RenderContext for VelloWindowRenderer {
     }
 
     fn unregister_resource(&mut self, resource_id: ResourceId) {
-        let RenderState::Active { active, .. } = &mut self.render_state else {
+        let RenderState::Active(active) = &mut self.render_state else {
             return;
         };
 
@@ -145,11 +140,11 @@ impl RenderContext for VelloWindowRenderer {
 
     fn renderer_specific_context(&self) -> Option<Box<dyn std::any::Any>> {
         match &self.render_state {
-            RenderState::Active { active, .. } => {
+            RenderState::Active(active) => {
                 Some(Box::new(active.render_surface.device_handle.clone()))
             }
             RenderState::Pending { .. } => None,
-            RenderState::Suspended { .. } => None,
+            RenderState::Suspended => None,
         }
     }
 }
@@ -185,60 +180,71 @@ impl WindowRenderer for VelloWindowRenderer {
         // construction). Calling while `Pending` or `Active` is a state-machine bug
         // in the embedder: it would orphan the in-flight init's `WGPUContext` and
         // pay for a fresh adapter+device init on the fallback path below.
-        debug_assert!(
-            matches!(self.render_state, RenderState::Suspended { .. }),
-            "WindowRenderer::resume called from non-Suspended state",
-        );
+        if !matches!(self.render_state, RenderState::Suspended) {
+            // #[cfg(feature = "tracing")]
+            // tracing::warn!("WindowRenderer::resume called from non-Suspended state");
+            return;
+        }
 
-        self.window_handle = Some(window_handle.clone());
         let (sender, receiver) = oneshot::channel();
-        let num_init_threads = DEFAULT_THREADS;
+        self.render_state = RenderState::Pending { receiver };
+        self.window_handle = Some(window_handle.clone());
 
-        // Take ownership of the WGPUContext so the init future can move it,
-        // and leave the channel receiver in its place. `mem::replace` lets us
-        // do both without fighting the borrow checker.
-        let prev = std::mem::replace(&mut self.render_state, RenderState::Pending { receiver });
-        let mut wgpu_context = match prev {
-            RenderState::Suspended { wgpu_context } => wgpu_context,
-            // Defensive: if a misbehaving caller hit this path, the in-flight
-            // init's context is orphaned and we pay for a fresh init.
-            _ => build_wgpu_context(&self.config),
-        };
+        let surface = self
+            .wgpu_context
+            .create_surface(window_handle)
+            .expect("Error creating surface");
+        let instance = self.wgpu_context.instance.clone();
+        let extra_features = self.wgpu_context.extra_features();
+        let override_limits = self.wgpu_context.override_limits();
+        let existing_device_handle = self
+            .wgpu_context
+            .find_compatible_device_handle(Some(&surface));
 
         spawn_init(async move {
-            let render_surface = wgpu_context
-                .create_surface(
-                    window_handle,
-                    SurfaceRendererConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        formats: vec![TextureFormat::Rgba8Unorm, TextureFormat::Bgra8Unorm],
-                        width,
-                        height,
-                        present_mode: PresentMode::AutoVsync,
-                        desired_maximum_frame_latency: 2,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                        view_formats: vec![],
-                    },
-                    Some(TextureConfiguration {
-                        usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
-                    }),
+            let device_handle = match existing_device_handle {
+                Some(device_handle) => device_handle,
+                None => DeviceHandle::new_from_compatible_surface(
+                    instance,
+                    Some(&surface),
+                    extra_features,
+                    override_limits,
                 )
                 .await
-                .expect("Error creating surface");
+                .expect("Error creating DeviceHandle"),
+            };
+
+            let render_surface = SurfaceRenderer::new(
+                surface,
+                SurfaceRendererConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    formats: vec![TextureFormat::Rgba8Unorm, TextureFormat::Bgra8Unorm],
+                    width,
+                    height,
+                    present_mode: PresentMode::AutoVsync,
+                    desired_maximum_frame_latency: 2,
+                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    view_formats: vec![],
+                },
+                Some(TextureConfiguration {
+                    usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
+                }),
+                device_handle,
+            )
+            .expect("Error creating SurfaceRenderer");
 
             let renderer = VelloRenderer::new(
                 render_surface.device(),
                 RendererOptions {
                     antialiasing_support: AaSupport::all(),
                     use_cpu: false,
-                    num_init_threads,
+                    num_init_threads: DEFAULT_THREADS,
                     pipeline_cache: None,
                 },
             )
             .unwrap();
 
             let _ = sender.send(InitOutput {
-                wgpu_context,
                 active: ActiveRenderState {
                     renderer,
                     render_surface,
@@ -249,60 +255,39 @@ impl WindowRenderer for VelloWindowRenderer {
     }
 
     fn complete_resume(&mut self) -> bool {
-        if let RenderState::Pending { receiver } = &mut self.render_state {
-            let Ok(Some(InitOutput {
-                wgpu_context,
-                active,
-            })) = receiver.try_recv()
-            else {
-                return false;
-            };
-
-            self.render_state = RenderState::Active {
-                wgpu_context,
-                active,
-            };
-            return true;
+        match &mut self.render_state {
+            RenderState::Active { .. } => true,
+            RenderState::Suspended => false,
+            RenderState::Pending { receiver } => match receiver.try_recv() {
+                Ok(Some(InitOutput { active })) => {
+                    let device_handle = active.render_surface.device_handle.clone();
+                    self.wgpu_context.device_pool.push(device_handle);
+                    self.render_state = RenderState::Active(active);
+                    true
+                }
+                _ => false,
+            },
         }
-        matches!(self.render_state, RenderState::Active { .. })
     }
 
     fn suspend(&mut self) {
-        if let RenderState::Active { active, .. } = &mut self.render_state {
+        if let RenderState::Active(active) = &mut self.render_state {
             // Unregister all textures on suspend
             for (_id, handle) in self.texture_handles.drain() {
                 active.renderer.unregister_texture(handle);
             }
         }
-
-        // Recover the WGPUContext (if any) and place it back into Suspended so
-        // the next resume cycle can reuse it. The temporary closed-channel
-        // Pending state satisfies mem::replace; it's overwritten before any
-        // observer can touch it.
-        let prev = std::mem::replace(
-            &mut self.render_state,
-            RenderState::Pending {
-                receiver: oneshot::channel().1,
-            },
-        );
-        let wgpu_context = match prev {
-            RenderState::Active { wgpu_context, .. } => wgpu_context,
-            RenderState::Suspended { wgpu_context } => wgpu_context,
-            // Suspended-during-Pending: the in-flight future owns the previous
-            // context and is orphaned. Cheap-rebuild for the next cycle.
-            RenderState::Pending { .. } => build_wgpu_context(&self.config),
-        };
-        self.render_state = RenderState::Suspended { wgpu_context };
+        self.render_state = RenderState::Suspended;
     }
 
     fn set_size(&mut self, width: u32, height: u32) {
-        if let RenderState::Active { active, .. } = &mut self.render_state {
+        if let RenderState::Active(active) = &mut self.render_state {
             active.render_surface.resize(width, height);
         };
     }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {
-        let RenderState::Active { active: state, .. } = &mut self.render_state else {
+        let RenderState::Active(state) = &mut self.render_state else {
             return;
         };
 

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -2,8 +2,10 @@ use anyrender::{
     RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
 };
 use debug_timer::debug_timer;
+use futures_channel::oneshot;
 use peniko::{Color, ImageData};
 use rustc_hash::FxHashMap;
+use std::future::Future;
 use std::sync::Arc;
 use vello::{
     AaConfig, AaSupport, RenderParams, Renderer as VelloRenderer, RendererOptions,
@@ -16,25 +18,35 @@ use wgpu_context::{
 
 use crate::{DEFAULT_THREADS, VelloScenePainter};
 
-// Simple struct to hold the state of the renderer
+#[cfg(target_arch = "wasm32")]
+fn spawn_init<F: Future<Output = ()> + 'static>(f: F) {
+    wasm_bindgen_futures::spawn_local(f);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_init<F: Future<Output = ()>>(f: F) {
+    pollster::block_on(f);
+}
+
 struct ActiveRenderState {
     renderer: VelloRenderer,
     render_surface: SurfaceRenderer<'static>,
 }
 
-#[allow(clippy::large_enum_variant)]
-enum RenderState {
-    Active(ActiveRenderState),
-    Suspended,
+/// Result of a successful asynchronous resume; both the active state and the
+/// `WGPUContext` are returned so the renderer can reclaim the context.
+struct InitOutput {
+    wgpu_context: WGPUContext,
+    active: ActiveRenderState,
 }
 
-impl RenderState {
-    fn current_device_handle(&self) -> Option<&DeviceHandle> {
-        let RenderState::Active(state) = self else {
-            return None;
-        };
-        Some(&state.render_surface.device_handle)
-    }
+#[allow(clippy::large_enum_variant)]
+enum RenderState {
+    Suspended,
+    Pending {
+        receiver: oneshot::Receiver<InitOutput>,
+    },
+    Active(ActiveRenderState),
 }
 
 #[derive(Clone)]
@@ -62,8 +74,9 @@ pub struct VelloWindowRenderer {
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
 
-    // Vello
-    wgpu_context: WGPUContext,
+    /// Optional so the spawned init future can take ownership of it. Restored from
+    /// the future's result inside `complete_resume`.
+    wgpu_context: Option<WGPUContext>,
     scene: VelloScene,
     config: VelloRendererOptions,
 
@@ -77,14 +90,8 @@ impl VelloWindowRenderer {
     }
 
     pub fn with_options(config: VelloRendererOptions) -> Self {
-        let features = config.features.unwrap_or_default()
-            | Features::CLEAR_TEXTURE
-            | Features::PIPELINE_CACHE;
         Self {
-            wgpu_context: WGPUContext::with_features_and_limits(
-                Some(features),
-                config.limits.clone(),
-            ),
+            wgpu_context: Some(build_wgpu_context(&config)),
             config,
             render_state: RenderState::Suspended,
             window_handle: None,
@@ -94,7 +101,10 @@ impl VelloWindowRenderer {
     }
 
     pub fn current_device_handle(&self) -> Option<&DeviceHandle> {
-        self.render_state.current_device_handle()
+        match &self.render_state {
+            RenderState::Active(state) => Some(&state.render_surface.device_handle),
+            _ => None,
+        }
     }
 }
 
@@ -132,10 +142,18 @@ impl RenderContext for VelloWindowRenderer {
             RenderState::Active(active_render_state) => Some(Box::new(
                 active_render_state.render_surface.device_handle.clone(),
             )),
+            RenderState::Pending { .. } => None,
             RenderState::Suspended => None,
         }
     }
 }
+
+fn build_wgpu_context(config: &VelloRendererOptions) -> WGPUContext {
+    let features =
+        config.features.unwrap_or_default() | Features::CLEAR_TEXTURE | Features::PIPELINE_CACHE;
+    WGPUContext::with_features_and_limits(Some(features), config.limits.clone())
+}
+
 impl WindowRenderer for VelloWindowRenderer {
     type ScenePainter<'a>
         = VelloScenePainter<'a, 'a>
@@ -146,58 +164,96 @@ impl WindowRenderer for VelloWindowRenderer {
         matches!(self.render_state, RenderState::Active(_))
     }
 
-    fn resume(&mut self, window_handle: Arc<dyn WindowHandle>, width: u32, height: u32) {
-        // Create wgpu_context::SurfaceRenderer
-        let render_surface = pollster::block_on(self.wgpu_context.create_surface(
-            window_handle.clone(),
-            SurfaceRendererConfiguration {
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                formats: vec![TextureFormat::Rgba8Unorm, TextureFormat::Bgra8Unorm],
-                width,
-                height,
-                present_mode: PresentMode::AutoVsync,
-                desired_maximum_frame_latency: 2,
-                alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                view_formats: vec![],
-            },
-            Some(TextureConfiguration {
-                usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
-            }),
-        ))
-        .expect("Error creating surface");
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        window_handle: Arc<dyn WindowHandle>,
+        width: u32,
+        height: u32,
+        on_ready: F,
+    ) {
+        // Drain the wgpu_context. If we were `Pending`, the previous future still holds
+        // its own context and will be silently abandoned (its `sender` becomes a no-op
+        // when the new receiver replaces it). Build a fresh context on first use.
+        let wgpu_context = self
+            .wgpu_context
+            .take()
+            .unwrap_or_else(|| build_wgpu_context(&self.config));
 
-        // Create vello::Renderer
-        let renderer = VelloRenderer::new(
-            render_surface.device(),
-            RendererOptions {
-                antialiasing_support: AaSupport::all(),
-                use_cpu: false,
-                num_init_threads: DEFAULT_THREADS,
-                // TODO: add pipeline cache
-                pipeline_cache: None,
-            },
-        )
-        .unwrap();
+        self.window_handle = Some(window_handle.clone());
+        let (sender, receiver) = oneshot::channel();
+        let num_init_threads = DEFAULT_THREADS;
 
-        // Set state to Active
-        self.window_handle = Some(window_handle);
-        self.render_state = RenderState::Active(ActiveRenderState {
-            renderer,
-            render_surface,
+        spawn_init(async move {
+            let mut wgpu_context = wgpu_context;
+            let render_surface = wgpu_context
+                .create_surface(
+                    window_handle,
+                    SurfaceRendererConfiguration {
+                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                        formats: vec![TextureFormat::Rgba8Unorm, TextureFormat::Bgra8Unorm],
+                        width,
+                        height,
+                        present_mode: PresentMode::AutoVsync,
+                        desired_maximum_frame_latency: 2,
+                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                        view_formats: vec![],
+                    },
+                    Some(TextureConfiguration {
+                        usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
+                    }),
+                )
+                .await
+                .expect("Error creating surface");
+
+            let renderer = VelloRenderer::new(
+                render_surface.device(),
+                RendererOptions {
+                    antialiasing_support: AaSupport::all(),
+                    use_cpu: false,
+                    num_init_threads,
+                    pipeline_cache: None,
+                },
+            )
+            .unwrap();
+
+            let _ = sender.send(InitOutput {
+                wgpu_context,
+                active: ActiveRenderState {
+                    renderer,
+                    render_surface,
+                },
+            });
+            on_ready();
         });
+
+        self.render_state = RenderState::Pending { receiver };
+    }
+
+    fn complete_resume(&mut self) -> bool {
+        if let RenderState::Pending { receiver } = &mut self.render_state {
+            let Ok(Some(InitOutput {
+                wgpu_context,
+                active,
+            })) = receiver.try_recv()
+            else {
+                return false;
+            };
+            self.wgpu_context = Some(wgpu_context);
+
+            self.render_state = RenderState::Active(active);
+            return true;
+        }
+        matches!(self.render_state, RenderState::Active(_))
     }
 
     fn suspend(&mut self) {
-        let RenderState::Active(state) = &mut self.render_state else {
-            return;
-        };
-
-        // Unregister all textures on suspend
-        for (_id, handle) in self.texture_handles.drain() {
-            state.renderer.unregister_texture(handle);
+        if let RenderState::Active(state) = &mut self.render_state {
+            // Unregister all textures on suspend
+            for (_id, handle) in self.texture_handles.drain() {
+                state.renderer.unregister_texture(handle);
+            }
         }
 
-        // Set state to Suspended
         self.render_state = RenderState::Suspended;
     }
 
@@ -269,9 +325,6 @@ impl WindowRenderer for VelloWindowRenderer {
 
         timer.record_time("wait");
         timer.print_times("vello: ");
-
-        // static COUNTER: AtomicU64 = AtomicU64::new(0);
-        // println!("FRAME {}", COUNTER.fetch_add(1, atomic::Ordering::Relaxed));
 
         // Empty the Vello scene (memory optimisation)
         self.scene.reset();

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -84,6 +84,7 @@ pub struct VelloWindowRenderer {
     // Resources
     texture_handles: FxHashMap<ResourceId, ImageData>,
 }
+
 impl VelloWindowRenderer {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -18,6 +18,10 @@ use wgpu_context::{
 
 use crate::{DEFAULT_THREADS, VelloScenePainter};
 
+/// Drive the wgpu init future. On wasm32 we spawn it onto the JS microtask
+/// queue (blocking is not allowed). On native we drive it inline with
+/// `pollster::block_on` — there's no ambient async runtime to spawn onto, and
+/// `on_ready` then fires before `resume` returns.
 #[cfg(target_arch = "wasm32")]
 fn spawn_init<F: Future<Output = ()> + 'static>(f: F) {
     wasm_bindgen_futures::spawn_local(f);
@@ -42,11 +46,16 @@ struct InitOutput {
 
 #[allow(clippy::large_enum_variant)]
 enum RenderState {
-    Suspended,
+    Suspended {
+        wgpu_context: WGPUContext,
+    },
     Pending {
         receiver: oneshot::Receiver<InitOutput>,
     },
-    Active(ActiveRenderState),
+    Active {
+        wgpu_context: WGPUContext,
+        active: ActiveRenderState,
+    },
 }
 
 #[derive(Clone)]
@@ -74,9 +83,6 @@ pub struct VelloWindowRenderer {
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
 
-    /// Optional so the spawned init future can take ownership of it. Restored from
-    /// the future's result inside `complete_resume`.
-    wgpu_context: Option<WGPUContext>,
     scene: VelloScene,
     config: VelloRendererOptions,
 
@@ -90,10 +96,10 @@ impl VelloWindowRenderer {
     }
 
     pub fn with_options(config: VelloRendererOptions) -> Self {
+        let wgpu_context = build_wgpu_context(&config);
         Self {
-            wgpu_context: Some(build_wgpu_context(&config)),
+            render_state: RenderState::Suspended { wgpu_context },
             config,
-            render_state: RenderState::Suspended,
             window_handle: None,
             scene: VelloScene::new(),
             texture_handles: FxHashMap::default(),
@@ -102,7 +108,7 @@ impl VelloWindowRenderer {
 
     pub fn current_device_handle(&self) -> Option<&DeviceHandle> {
         match &self.render_state {
-            RenderState::Active(state) => Some(&state.render_surface.device_handle),
+            RenderState::Active { active, .. } => Some(&active.render_surface.device_handle),
             _ => None,
         }
     }
@@ -113,14 +119,14 @@ impl RenderContext for VelloWindowRenderer {
         &mut self,
         resource: Box<dyn std::any::Any>,
     ) -> Result<ResourceId, anyrender::RegisterResourceError> {
-        let RenderState::Active(state) = &mut self.render_state else {
+        let RenderState::Active { active, .. } = &mut self.render_state else {
             return Err(RegisterResourceErrorKind::NotActive.into());
         };
 
         if let Ok(texture) = resource.downcast::<Texture>() {
             let id = ResourceId::new();
             self.texture_handles
-                .insert(id, state.renderer.register_texture(*texture));
+                .insert(id, active.renderer.register_texture(*texture));
             Ok(id)
         } else {
             Err(anyrender::RegisterResourceErrorKind::UnsupportedResourceKind.into())
@@ -128,22 +134,22 @@ impl RenderContext for VelloWindowRenderer {
     }
 
     fn unregister_resource(&mut self, resource_id: ResourceId) {
-        let RenderState::Active(state) = &mut self.render_state else {
+        let RenderState::Active { active, .. } = &mut self.render_state else {
             return;
         };
 
         if let Some(handle) = self.texture_handles.remove(&resource_id) {
-            state.renderer.unregister_texture(handle);
+            active.renderer.unregister_texture(handle);
         }
     }
 
     fn renderer_specific_context(&self) -> Option<Box<dyn std::any::Any>> {
         match &self.render_state {
-            RenderState::Active(active_render_state) => Some(Box::new(
-                active_render_state.render_surface.device_handle.clone(),
-            )),
+            RenderState::Active { active, .. } => {
+                Some(Box::new(active.render_surface.device_handle.clone()))
+            }
             RenderState::Pending { .. } => None,
-            RenderState::Suspended => None,
+            RenderState::Suspended { .. } => None,
         }
     }
 }
@@ -161,7 +167,11 @@ impl WindowRenderer for VelloWindowRenderer {
         Self: 'a;
 
     fn is_active(&self) -> bool {
-        matches!(self.render_state, RenderState::Active(_))
+        matches!(self.render_state, RenderState::Active { .. })
+    }
+
+    fn is_pending(&self) -> bool {
+        matches!(self.render_state, RenderState::Pending { .. })
     }
 
     fn resume<F: FnOnce() + 'static>(
@@ -171,20 +181,31 @@ impl WindowRenderer for VelloWindowRenderer {
         height: u32,
         on_ready: F,
     ) {
-        // Drain the wgpu_context. If we were `Pending`, the previous future still holds
-        // its own context and will be silently abandoned (its `sender` becomes a no-op
-        // when the new receiver replaces it). Build a fresh context on first use.
-        let wgpu_context = self
-            .wgpu_context
-            .take()
-            .unwrap_or_else(|| build_wgpu_context(&self.config));
+        // Each `resume` must be preceded by `suspend` (or be the first call after
+        // construction). Calling while `Pending` or `Active` is a state-machine bug
+        // in the embedder: it would orphan the in-flight init's `WGPUContext` and
+        // pay for a fresh adapter+device init on the fallback path below.
+        debug_assert!(
+            matches!(self.render_state, RenderState::Suspended { .. }),
+            "WindowRenderer::resume called from non-Suspended state",
+        );
 
         self.window_handle = Some(window_handle.clone());
         let (sender, receiver) = oneshot::channel();
         let num_init_threads = DEFAULT_THREADS;
 
+        // Take ownership of the WGPUContext so the init future can move it,
+        // and leave the channel receiver in its place. `mem::replace` lets us
+        // do both without fighting the borrow checker.
+        let prev = std::mem::replace(&mut self.render_state, RenderState::Pending { receiver });
+        let mut wgpu_context = match prev {
+            RenderState::Suspended { wgpu_context } => wgpu_context,
+            // Defensive: if a misbehaving caller hit this path, the in-flight
+            // init's context is orphaned and we pay for a fresh init.
+            _ => build_wgpu_context(&self.config),
+        };
+
         spawn_init(async move {
-            let mut wgpu_context = wgpu_context;
             let render_surface = wgpu_context
                 .create_surface(
                     window_handle,
@@ -225,8 +246,6 @@ impl WindowRenderer for VelloWindowRenderer {
             });
             on_ready();
         });
-
-        self.render_state = RenderState::Pending { receiver };
     }
 
     fn complete_resume(&mut self) -> bool {
@@ -238,33 +257,52 @@ impl WindowRenderer for VelloWindowRenderer {
             else {
                 return false;
             };
-            self.wgpu_context = Some(wgpu_context);
 
-            self.render_state = RenderState::Active(active);
+            self.render_state = RenderState::Active {
+                wgpu_context,
+                active,
+            };
             return true;
         }
-        matches!(self.render_state, RenderState::Active(_))
+        matches!(self.render_state, RenderState::Active { .. })
     }
 
     fn suspend(&mut self) {
-        if let RenderState::Active(state) = &mut self.render_state {
+        if let RenderState::Active { active, .. } = &mut self.render_state {
             // Unregister all textures on suspend
             for (_id, handle) in self.texture_handles.drain() {
-                state.renderer.unregister_texture(handle);
+                active.renderer.unregister_texture(handle);
             }
         }
 
-        self.render_state = RenderState::Suspended;
+        // Recover the WGPUContext (if any) and place it back into Suspended so
+        // the next resume cycle can reuse it. The temporary closed-channel
+        // Pending state satisfies mem::replace; it's overwritten before any
+        // observer can touch it.
+        let prev = std::mem::replace(
+            &mut self.render_state,
+            RenderState::Pending {
+                receiver: oneshot::channel().1,
+            },
+        );
+        let wgpu_context = match prev {
+            RenderState::Active { wgpu_context, .. } => wgpu_context,
+            RenderState::Suspended { wgpu_context } => wgpu_context,
+            // Suspended-during-Pending: the in-flight future owns the previous
+            // context and is orphaned. Cheap-rebuild for the next cycle.
+            RenderState::Pending { .. } => build_wgpu_context(&self.config),
+        };
+        self.render_state = RenderState::Suspended { wgpu_context };
     }
 
     fn set_size(&mut self, width: u32, height: u32) {
-        if let RenderState::Active(state) = &mut self.render_state {
-            state.render_surface.resize(width, height);
+        if let RenderState::Active { active, .. } = &mut self.render_state {
+            active.render_surface.resize(width, height);
         };
     }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {
-        let RenderState::Active(state) = &mut self.render_state else {
+        let RenderState::Active { active: state, .. } = &mut self.render_state else {
             return;
         };
 
@@ -293,7 +331,7 @@ impl WindowRenderer for VelloWindowRenderer {
 
         let texture_view = render_surface
             .target_texture_view()
-            .expect("handled errorss from ensure_current_surface_texture above");
+            .expect("handled errors from ensure_current_surface_texture above");
         state
             .renderer
             .render_to_texture(
@@ -315,7 +353,7 @@ impl WindowRenderer for VelloWindowRenderer {
 
         render_surface
             .maybe_blit_and_present()
-            .expect("handled errorss from ensure_current_surface_texture above");
+            .expect("handled errors from ensure_current_surface_texture above");
         timer.record_time("present");
 
         render_surface

--- a/crates/anyrender_vello_hybrid/Cargo.toml
+++ b/crates/anyrender_vello_hybrid/Cargo.toml
@@ -20,6 +20,12 @@ peniko = { workspace = true }
 vello_hybrid = { workspace = true }
 vello_common = { workspace = true }
 wgpu = { workspace = true }
-pollster = { workspace = true }
 rustc-hash = { workspace = true }
 wgpu_context = { workspace = true }
+futures-channel = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pollster = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { workspace = true }

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -1,10 +1,9 @@
 use anyrender::{RenderContext, WindowHandle, WindowRenderer};
 use debug_timer::debug_timer;
+use futures_channel::oneshot;
 use rustc_hash::FxHashMap;
-use std::sync::{
-    Arc,
-    // atomic::{AtomicU64},
-};
+use std::future::Future;
+use std::sync::Arc;
 use vello_common::paint::ImageId;
 use vello_hybrid::{
     RenderSettings, RenderSize, RenderTargetConfig, Renderer as VelloHybridRenderer,
@@ -14,29 +13,36 @@ use wgpu::{CommandEncoderDescriptor, Features, Limits, PresentMode, SurfaceError
 use wgpu_context::{DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, WGPUContext};
 
 use crate::{VelloHybridScenePainter, scene::ImageManager};
-// use crate::CustomPaintSource;
 
-// static PAINT_SOURCE_ID: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_arch = "wasm32")]
+fn spawn_init<F: Future<Output = ()> + 'static>(f: F) {
+    wasm_bindgen_futures::spawn_local(f);
+}
 
-// Simple struct to hold the state of the renderer
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_init<F: Future<Output = ()>>(f: F) {
+    pollster::block_on(f);
+}
+
 struct ActiveRenderState {
     renderer: VelloHybridRenderer,
     render_surface: SurfaceRenderer<'static>,
 }
 
-#[allow(clippy::large_enum_variant)]
-enum RenderState {
-    Active(ActiveRenderState),
-    Suspended,
+/// Result of a successful asynchronous resume; both the active state and the
+/// `WGPUContext` are returned so the renderer can reclaim the context.
+struct InitOutput {
+    wgpu_context: WGPUContext,
+    active: ActiveRenderState,
 }
 
-impl RenderState {
-    fn current_device_handle(&self) -> Option<&DeviceHandle> {
-        let RenderState::Active(state) = self else {
-            return None;
-        };
-        Some(&state.render_surface.device_handle)
-    }
+#[allow(clippy::large_enum_variant)]
+enum RenderState {
+    Suspended,
+    Pending {
+        receiver: oneshot::Receiver<InitOutput>,
+    },
+    Active(ActiveRenderState),
 }
 
 #[derive(Clone, Default)]
@@ -52,11 +58,11 @@ pub struct VelloHybridWindowRenderer {
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
 
-    // Vello
-    wgpu_context: WGPUContext,
+    /// Optional so the spawned init future can take ownership of it. Restored from
+    /// the future's result inside `complete_resume`.
+    wgpu_context: Option<WGPUContext>,
     scene: VelloHybridScene,
     config: VelloHybridRendererOptions,
-    // custom_paint_sources: FxHashMap<u64, Box<dyn CustomPaintSource>>,
     cached_images: FxHashMap<u64, ImageId>,
 }
 impl VelloHybridWindowRenderer {
@@ -66,44 +72,29 @@ impl VelloHybridWindowRenderer {
     }
 
     pub fn with_options(config: VelloHybridRendererOptions) -> Self {
-        let features = config.features.unwrap_or_default()
-            | Features::CLEAR_TEXTURE
-            | Features::PIPELINE_CACHE;
         let render_settings = config.render_settings;
         Self {
-            wgpu_context: WGPUContext::with_features_and_limits(
-                Some(features),
-                config.limits.clone(),
-            ),
+            wgpu_context: Some(build_wgpu_context(&config)),
             config,
             render_state: RenderState::Suspended,
             window_handle: None,
             scene: VelloHybridScene::new_with(0, 0, render_settings),
-            // custom_paint_sources: FxHashMap::default(),
             cached_images: FxHashMap::default(),
         }
     }
 
     pub fn current_device_handle(&self) -> Option<&DeviceHandle> {
-        self.render_state.current_device_handle()
+        match &self.render_state {
+            RenderState::Active(state) => Some(&state.render_surface.device_handle),
+            _ => None,
+        }
     }
+}
 
-    // pub fn register_custom_paint_source(&mut self, mut source: Box<dyn CustomPaintSource>) -> u64 {
-    //     if let Some(device_handle) = self.render_state.current_device_handle() {
-    //         source.resume(device_handle);
-    //     }
-    //     let id = PAINT_SOURCE_ID.fetch_add(1, atomic::Ordering::SeqCst);
-    //     self.custom_paint_sources.insert(id, source);
-
-    //     id
-    // }
-
-    // pub fn unregister_custom_paint_source(&mut self, id: u64) {
-    //     if let Some(mut source) = self.custom_paint_sources.remove(&id) {
-    //         source.suspend();
-    //         drop(source);
-    //     }
-    // }
+fn build_wgpu_context(config: &VelloHybridRendererOptions) -> WGPUContext {
+    let features =
+        config.features.unwrap_or_default() | Features::CLEAR_TEXTURE | Features::PIPELINE_CACHE;
+    WGPUContext::with_features_and_limits(Some(features), config.limits.clone())
 }
 
 // TODO: Make configurable?
@@ -159,62 +150,85 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         matches!(self.render_state, RenderState::Active(_))
     }
 
-    fn resume(&mut self, window_handle: Arc<dyn WindowHandle>, width: u32, height: u32) {
-        // Create wgpu_context::SurfaceRenderer
-        let render_surface = pollster::block_on(self.wgpu_context.create_surface(
-            window_handle.clone(),
-            SurfaceRendererConfiguration {
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                formats: vec![DEFAULT_TEXTURE_FORMAT],
-                width,
-                height,
-                present_mode: PresentMode::AutoVsync,
-                desired_maximum_frame_latency: 2,
-                alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                view_formats: vec![],
-            },
-            None,
-            // Some(TextureConfiguration {
-            //     usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
-            // }),
-        ))
-        .expect("Error creating surface");
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        window_handle: Arc<dyn WindowHandle>,
+        width: u32,
+        height: u32,
+        on_ready: F,
+    ) {
+        let wgpu_context = self
+            .wgpu_context
+            .take()
+            .unwrap_or_else(|| build_wgpu_context(&self.config));
 
-        // Create vello::Renderer
-        let renderer = VelloHybridRenderer::new(
-            render_surface.device(),
-            &RenderTargetConfig {
-                format: DEFAULT_TEXTURE_FORMAT,
-                width,
-                height,
-            },
-        );
+        self.window_handle = Some(window_handle.clone());
+        let (sender, receiver) = oneshot::channel();
+        let render_settings = self.config.render_settings;
 
-        // Resume custom paint sources
-        // let device_handle = &render_surface.device_handle;
-        // for source in self.custom_paint_sources.values_mut() {
-        //     source.resume(device_handle)
-        // }
+        // Reset the scene to the new dimensions before init kicks off, so callers that
+        // query scene size (e.g. `set_size`) see consistent state.
+        self.scene = VelloHybridScene::new_with(width as u16, height as u16, render_settings);
 
-        // Create a Scene with the correct dimensions
-        self.scene =
-            VelloHybridScene::new_with(width as u16, height as u16, self.config.render_settings);
+        spawn_init(async move {
+            let mut wgpu_context = wgpu_context;
+            let render_surface = wgpu_context
+                .create_surface(
+                    window_handle,
+                    SurfaceRendererConfiguration {
+                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                        formats: vec![DEFAULT_TEXTURE_FORMAT],
+                        width,
+                        height,
+                        present_mode: PresentMode::AutoVsync,
+                        desired_maximum_frame_latency: 2,
+                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                        view_formats: vec![],
+                    },
+                    None,
+                )
+                .await
+                .expect("Error creating surface");
 
-        // Set state to Active
-        self.window_handle = Some(window_handle);
-        self.render_state = RenderState::Active(ActiveRenderState {
-            renderer,
-            render_surface,
+            let renderer = VelloHybridRenderer::new(
+                render_surface.device(),
+                &RenderTargetConfig {
+                    format: DEFAULT_TEXTURE_FORMAT,
+                    width,
+                    height,
+                },
+            );
+
+            let _ = sender.send(InitOutput {
+                wgpu_context,
+                active: ActiveRenderState {
+                    renderer,
+                    render_surface,
+                },
+            });
+            on_ready();
         });
+
+        self.render_state = RenderState::Pending { receiver };
+    }
+
+    fn complete_resume(&mut self) -> bool {
+        if let RenderState::Pending { receiver } = &mut self.render_state {
+            let Ok(Some(InitOutput {
+                wgpu_context,
+                active,
+            })) = receiver.try_recv()
+            else {
+                return false;
+            };
+            self.wgpu_context = Some(wgpu_context);
+            self.render_state = RenderState::Active(active);
+            return true;
+        }
+        matches!(self.render_state, RenderState::Active(_))
     }
 
     fn suspend(&mut self) {
-        // Suspend custom paint sources
-        // for source in self.custom_paint_sources.values_mut() {
-        //     source.suspend()
-        // }
-
-        // Set state to Suspended
         self.render_state = RenderState::Suspended;
     }
 
@@ -308,9 +322,6 @@ impl WindowRenderer for VelloHybridWindowRenderer {
 
         timer.record_time("wait");
         timer.print_times("vello_hybrid: ");
-
-        // static COUNTER: AtomicU64 = AtomicU64::new(0);
-        // println!("FRAME {}", COUNTER.fetch_add(1, atomic::Ordering::Relaxed));
 
         // Empty the Vello scene (memory optimisation)
         self.scene.reset();

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -36,22 +36,16 @@ struct ActiveRenderState {
 /// Result of a successful asynchronous resume; both the active state and the
 /// `WGPUContext` are returned so the renderer can reclaim the context.
 struct InitOutput {
-    wgpu_context: WGPUContext,
     active: ActiveRenderState,
 }
 
 #[allow(clippy::large_enum_variant)]
 enum RenderState {
-    Suspended {
-        wgpu_context: WGPUContext,
-    },
+    Suspended,
     Pending {
         receiver: oneshot::Receiver<InitOutput>,
     },
-    Active {
-        wgpu_context: WGPUContext,
-        active: ActiveRenderState,
-    },
+    Active(ActiveRenderState),
 }
 
 #[derive(Clone, Default)]
@@ -67,6 +61,7 @@ pub struct VelloHybridWindowRenderer {
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
 
+    wgpu_context: WGPUContext,
     scene: VelloHybridScene,
     config: VelloHybridRendererOptions,
     cached_images: FxHashMap<u64, ImageId>,
@@ -81,8 +76,9 @@ impl VelloHybridWindowRenderer {
         let render_settings = config.render_settings;
         let wgpu_context = build_wgpu_context(&config);
         Self {
-            render_state: RenderState::Suspended { wgpu_context },
+            render_state: RenderState::Suspended,
             config,
+            wgpu_context,
             window_handle: None,
             scene: VelloHybridScene::new_with(0, 0, render_settings),
             cached_images: FxHashMap::default(),
@@ -91,7 +87,7 @@ impl VelloHybridWindowRenderer {
 
     pub fn current_device_handle(&self) -> Option<&DeviceHandle> {
         match &self.render_state {
-            RenderState::Active { active, .. } => Some(&active.render_surface.device_handle),
+            RenderState::Active(active) => Some(&active.render_surface.device_handle),
             _ => None,
         }
     }
@@ -171,46 +167,61 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         // construction). Calling while `Pending` or `Active` is a state-machine bug
         // in the embedder: it would orphan the in-flight init's `WGPUContext` and
         // pay for a fresh adapter+device init on the fallback path below.
-        debug_assert!(
-            matches!(self.render_state, RenderState::Suspended { .. }),
-            "WindowRenderer::resume called from non-Suspended state",
-        );
+        if !matches!(self.render_state, RenderState::Suspended) {
+            // #[cfg(feature = "tracing")]
+            // tracing::warn!("WindowRenderer::resume called from non-Suspended state");
+            return;
+        }
 
-        self.window_handle = Some(window_handle.clone());
         let (sender, receiver) = oneshot::channel();
-        let render_settings = self.config.render_settings;
+        self.render_state = RenderState::Pending { receiver };
+        self.window_handle = Some(window_handle.clone());
 
         // Reset the scene to the new dimensions before init kicks off, so callers that
         // query scene size (e.g. `set_size`) see consistent state.
+        let render_settings = self.config.render_settings;
         self.scene = VelloHybridScene::new_with(width as u16, height as u16, render_settings);
 
-        // Take ownership of the WGPUContext so the init future can move it,
-        // and leave the channel receiver in its place. `mem::replace` lets us
-        // do both without fighting the borrow checker.
-        let prev = std::mem::replace(&mut self.render_state, RenderState::Pending { receiver });
-        let mut wgpu_context = match prev {
-            RenderState::Suspended { wgpu_context } => wgpu_context,
-            _ => build_wgpu_context(&self.config),
-        };
+        let surface = self
+            .wgpu_context
+            .create_surface(window_handle)
+            .expect("Error creating surface");
+        let instance = self.wgpu_context.instance.clone();
+        let extra_features = self.wgpu_context.extra_features();
+        let override_limits = self.wgpu_context.override_limits();
+        let existing_device_handle = self
+            .wgpu_context
+            .find_compatible_device_handle(Some(&surface));
 
         spawn_init(async move {
-            let render_surface = wgpu_context
-                .create_surface(
-                    window_handle,
-                    SurfaceRendererConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        formats: vec![DEFAULT_TEXTURE_FORMAT],
-                        width,
-                        height,
-                        present_mode: PresentMode::AutoVsync,
-                        desired_maximum_frame_latency: 2,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                        view_formats: vec![],
-                    },
-                    None,
+            let device_handle = match existing_device_handle {
+                Some(device_handle) => device_handle,
+                None => DeviceHandle::new_from_compatible_surface(
+                    instance,
+                    Some(&surface),
+                    extra_features,
+                    override_limits,
                 )
                 .await
-                .expect("Error creating surface");
+                .expect("Error creating DeviceHandle"),
+            };
+
+            let render_surface = SurfaceRenderer::new(
+                surface,
+                SurfaceRendererConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    formats: vec![DEFAULT_TEXTURE_FORMAT],
+                    width,
+                    height,
+                    present_mode: PresentMode::AutoVsync,
+                    desired_maximum_frame_latency: 2,
+                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    view_formats: vec![],
+                },
+                None,
+                device_handle,
+            )
+            .expect("Error creating SurfaceRenderer");
 
             let renderer = VelloHybridRenderer::new(
                 render_surface.device(),
@@ -222,7 +233,6 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             );
 
             let _ = sender.send(InitOutput {
-                wgpu_context,
                 active: ActiveRenderState {
                     renderer,
                     render_surface,
@@ -233,39 +243,23 @@ impl WindowRenderer for VelloHybridWindowRenderer {
     }
 
     fn complete_resume(&mut self) -> bool {
-        if let RenderState::Pending { receiver } = &mut self.render_state {
-            let Ok(Some(InitOutput {
-                wgpu_context,
-                active,
-            })) = receiver.try_recv()
-            else {
-                return false;
-            };
-            self.render_state = RenderState::Active {
-                wgpu_context,
-                active,
-            };
-            return true;
+        match &mut self.render_state {
+            RenderState::Active { .. } => true,
+            RenderState::Suspended => false,
+            RenderState::Pending { receiver } => match receiver.try_recv() {
+                Ok(Some(InitOutput { active })) => {
+                    let device_handle = active.render_surface.device_handle.clone();
+                    self.wgpu_context.device_pool.push(device_handle);
+                    self.render_state = RenderState::Active(active);
+                    true
+                }
+                _ => false,
+            },
         }
-        matches!(self.render_state, RenderState::Active { .. })
     }
 
     fn suspend(&mut self) {
-        // Recover the WGPUContext (if any) and place it back into Suspended.
-        // Temporary closed-channel Pending state satisfies mem::replace; it's
-        // overwritten before any observer can touch it.
-        let prev = std::mem::replace(
-            &mut self.render_state,
-            RenderState::Pending {
-                receiver: oneshot::channel().1,
-            },
-        );
-        let wgpu_context = match prev {
-            RenderState::Active { wgpu_context, .. } => wgpu_context,
-            RenderState::Suspended { wgpu_context } => wgpu_context,
-            RenderState::Pending { .. } => build_wgpu_context(&self.config),
-        };
-        self.render_state = RenderState::Suspended { wgpu_context };
+        self.render_state = RenderState::Suspended;
     }
 
     fn set_size(&mut self, width: u32, height: u32) {
@@ -275,14 +269,14 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                 height as u16,
                 self.config.render_settings,
             );
-            if let RenderState::Active { active, .. } = &mut self.render_state {
+            if let RenderState::Active(active) = &mut self.render_state {
                 active.render_surface.resize(width, height);
             };
         }
     }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {
-        let RenderState::Active { active: state, .. } = &mut self.render_state else {
+        let RenderState::Active(state) = &mut self.render_state else {
             return;
         };
 

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -14,6 +14,10 @@ use wgpu_context::{DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, 
 
 use crate::{VelloHybridScenePainter, scene::ImageManager};
 
+/// Drive the wgpu init future. On wasm32 we spawn it onto the JS microtask
+/// queue (blocking is not allowed). On native we drive it inline with
+/// `pollster::block_on` — there's no ambient async runtime to spawn onto, and
+/// `on_ready` then fires before `resume` returns.
 #[cfg(target_arch = "wasm32")]
 fn spawn_init<F: Future<Output = ()> + 'static>(f: F) {
     wasm_bindgen_futures::spawn_local(f);
@@ -38,11 +42,16 @@ struct InitOutput {
 
 #[allow(clippy::large_enum_variant)]
 enum RenderState {
-    Suspended,
+    Suspended {
+        wgpu_context: WGPUContext,
+    },
     Pending {
         receiver: oneshot::Receiver<InitOutput>,
     },
-    Active(ActiveRenderState),
+    Active {
+        wgpu_context: WGPUContext,
+        active: ActiveRenderState,
+    },
 }
 
 #[derive(Clone, Default)]
@@ -58,9 +67,6 @@ pub struct VelloHybridWindowRenderer {
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
 
-    /// Optional so the spawned init future can take ownership of it. Restored from
-    /// the future's result inside `complete_resume`.
-    wgpu_context: Option<WGPUContext>,
     scene: VelloHybridScene,
     config: VelloHybridRendererOptions,
     cached_images: FxHashMap<u64, ImageId>,
@@ -73,10 +79,10 @@ impl VelloHybridWindowRenderer {
 
     pub fn with_options(config: VelloHybridRendererOptions) -> Self {
         let render_settings = config.render_settings;
+        let wgpu_context = build_wgpu_context(&config);
         Self {
-            wgpu_context: Some(build_wgpu_context(&config)),
+            render_state: RenderState::Suspended { wgpu_context },
             config,
-            render_state: RenderState::Suspended,
             window_handle: None,
             scene: VelloHybridScene::new_with(0, 0, render_settings),
             cached_images: FxHashMap::default(),
@@ -85,7 +91,7 @@ impl VelloHybridWindowRenderer {
 
     pub fn current_device_handle(&self) -> Option<&DeviceHandle> {
         match &self.render_state {
-            RenderState::Active(state) => Some(&state.render_surface.device_handle),
+            RenderState::Active { active, .. } => Some(&active.render_surface.device_handle),
             _ => None,
         }
     }
@@ -147,7 +153,11 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         Self: 'a;
 
     fn is_active(&self) -> bool {
-        matches!(self.render_state, RenderState::Active(_))
+        matches!(self.render_state, RenderState::Active { .. })
+    }
+
+    fn is_pending(&self) -> bool {
+        matches!(self.render_state, RenderState::Pending { .. })
     }
 
     fn resume<F: FnOnce() + 'static>(
@@ -157,10 +167,14 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         height: u32,
         on_ready: F,
     ) {
-        let wgpu_context = self
-            .wgpu_context
-            .take()
-            .unwrap_or_else(|| build_wgpu_context(&self.config));
+        // Each `resume` must be preceded by `suspend` (or be the first call after
+        // construction). Calling while `Pending` or `Active` is a state-machine bug
+        // in the embedder: it would orphan the in-flight init's `WGPUContext` and
+        // pay for a fresh adapter+device init on the fallback path below.
+        debug_assert!(
+            matches!(self.render_state, RenderState::Suspended { .. }),
+            "WindowRenderer::resume called from non-Suspended state",
+        );
 
         self.window_handle = Some(window_handle.clone());
         let (sender, receiver) = oneshot::channel();
@@ -170,8 +184,16 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         // query scene size (e.g. `set_size`) see consistent state.
         self.scene = VelloHybridScene::new_with(width as u16, height as u16, render_settings);
 
+        // Take ownership of the WGPUContext so the init future can move it,
+        // and leave the channel receiver in its place. `mem::replace` lets us
+        // do both without fighting the borrow checker.
+        let prev = std::mem::replace(&mut self.render_state, RenderState::Pending { receiver });
+        let mut wgpu_context = match prev {
+            RenderState::Suspended { wgpu_context } => wgpu_context,
+            _ => build_wgpu_context(&self.config),
+        };
+
         spawn_init(async move {
-            let mut wgpu_context = wgpu_context;
             let render_surface = wgpu_context
                 .create_surface(
                     window_handle,
@@ -208,8 +230,6 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             });
             on_ready();
         });
-
-        self.render_state = RenderState::Pending { receiver };
     }
 
     fn complete_resume(&mut self) -> bool {
@@ -221,15 +241,31 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             else {
                 return false;
             };
-            self.wgpu_context = Some(wgpu_context);
-            self.render_state = RenderState::Active(active);
+            self.render_state = RenderState::Active {
+                wgpu_context,
+                active,
+            };
             return true;
         }
-        matches!(self.render_state, RenderState::Active(_))
+        matches!(self.render_state, RenderState::Active { .. })
     }
 
     fn suspend(&mut self) {
-        self.render_state = RenderState::Suspended;
+        // Recover the WGPUContext (if any) and place it back into Suspended.
+        // Temporary closed-channel Pending state satisfies mem::replace; it's
+        // overwritten before any observer can touch it.
+        let prev = std::mem::replace(
+            &mut self.render_state,
+            RenderState::Pending {
+                receiver: oneshot::channel().1,
+            },
+        );
+        let wgpu_context = match prev {
+            RenderState::Active { wgpu_context, .. } => wgpu_context,
+            RenderState::Suspended { wgpu_context } => wgpu_context,
+            RenderState::Pending { .. } => build_wgpu_context(&self.config),
+        };
+        self.render_state = RenderState::Suspended { wgpu_context };
     }
 
     fn set_size(&mut self, width: u32, height: u32) {
@@ -239,14 +275,14 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                 height as u16,
                 self.config.render_settings,
             );
-            if let RenderState::Active(state) = &mut self.render_state {
-                state.render_surface.resize(width, height);
+            if let RenderState::Active { active, .. } = &mut self.render_state {
+                active.render_surface.resize(width, height);
             };
         }
     }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {
-        let RenderState::Active(state) = &mut self.render_state else {
+        let RenderState::Active { active: state, .. } = &mut self.render_state else {
             return;
         };
 
@@ -289,7 +325,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
 
         let texture_view = render_surface
             .target_texture_view()
-            .expect("handled errorss from ensure_current_surface_texture above");
+            .expect("handled errors from ensure_current_surface_texture above");
 
         state
             .renderer
@@ -312,7 +348,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
 
         render_surface
             .maybe_blit_and_present()
-            .expect("handled errorss from ensure_current_surface_texture above");
+            .expect("handled errors from ensure_current_surface_texture above");
         timer.record_time("present");
 
         render_surface

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -87,6 +87,10 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         on_ready();
     }
 
+    fn complete_resume(&mut self) -> bool {
+        true
+    }
+
     fn suspend(&mut self) {
         self.render_state = RenderState::Suspended;
     }

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -64,7 +64,13 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         matches!(self.render_state, RenderState::Active(_))
     }
 
-    fn resume(&mut self, window_handle: Arc<dyn WindowHandle>, width: u32, height: u32) {
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        window_handle: Arc<dyn WindowHandle>,
+        width: u32,
+        height: u32,
+        on_ready: F,
+    ) {
         let surface = SurfaceTexture::new(width, height, window_handle.clone());
         let mut pixels = Pixels::new(width, height, surface).unwrap();
         pixels.enable_vsync(true);
@@ -78,6 +84,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         self.window_handle = Some(window_handle);
 
         self.set_size(width, height);
+        on_ready();
     }
 
     fn suspend(&mut self) {

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -85,6 +85,10 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         on_ready();
     }
 
+    fn complete_resume(&mut self) -> bool {
+        true
+    }
+
     fn suspend(&mut self) {
         self.render_state = RenderState::Suspended;
     }

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -66,7 +66,13 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         matches!(self.render_state, RenderState::Active(_))
     }
 
-    fn resume(&mut self, window_handle: Arc<dyn WindowHandle>, width: u32, height: u32) {
+    fn resume<F: FnOnce() + 'static>(
+        &mut self,
+        window_handle: Arc<dyn WindowHandle>,
+        width: u32,
+        height: u32,
+        on_ready: F,
+    ) {
         let context = Context::new(window_handle.clone()).unwrap();
         let surface = Surface::new(&context, window_handle.clone()).unwrap();
         self.render_state = RenderState::Active(ActiveRenderState {
@@ -76,6 +82,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         self.window_handle = Some(window_handle);
 
         self.set_size(width, height);
+        on_ready();
     }
 
     fn suspend(&mut self) {

--- a/crates/wgpu_context/src/lib.rs
+++ b/crates/wgpu_context/src/lib.rs
@@ -26,6 +26,66 @@ pub struct DeviceHandle {
     pub queue: Queue,
 }
 
+impl DeviceHandle {
+    /// Creates a `DeviceHandle` with `Device` that's compatible with the specified `Surface`
+    pub async fn new_from_compatible_surface(
+        instance: Instance,
+        compatible_surface: Option<&Surface<'_>>,
+        extra_features: Option<Features>,
+        override_limits: Option<Limits>,
+    ) -> Result<Self, WgpuContextError> {
+        let adapter =
+            wgpu::util::initialize_adapter_from_env_or_default(&instance, compatible_surface)
+                .await?;
+
+        // Determine features to request
+        // The user may request additional features
+        let requested_features = extra_features.unwrap_or(Features::empty());
+        let available_features = adapter.features();
+        let required_features = requested_features & available_features;
+
+        // Determine limits to request
+        // The user may override the limits
+        let required_limits = override_limits.clone().unwrap_or_default();
+
+        // Create the device and the queue
+        let descripter = wgpu::DeviceDescriptor {
+            label: None,
+            required_features,
+            required_limits,
+            memory_hints: MemoryHints::MemoryUsage,
+            trace: wgpu::Trace::default(),
+            experimental_features: wgpu::ExperimentalFeatures::default(),
+        };
+        let (device, queue) = adapter.request_device(&descripter).await?;
+
+        // Create the device handle and store in the pool
+        Ok(DeviceHandle {
+            instance,
+            adapter,
+            device,
+            queue,
+        })
+    }
+
+    /// Creates a new surface for the specified window and dimensions.
+    pub async fn create_surface<'w>(
+        &mut self,
+        window: impl Into<SurfaceTarget<'w>>,
+        surface_config: SurfaceRendererConfiguration,
+        intermediate_texture_config: Option<TextureConfiguration>,
+    ) -> Result<SurfaceRenderer<'w>, WgpuContextError> {
+        // Create a surface from the window handle
+        let surface = self.instance.create_surface(window.into())?;
+        SurfaceRenderer::new(
+            surface,
+            surface_config,
+            intermediate_texture_config,
+            self.clone(),
+        )
+    }
+}
+
 /// Simple render context that maintains wgpu state for rendering the pipeline.
 pub struct WGPUContext {
     /// A WGPU `Instance`. This only needs to be created once per application.
@@ -67,15 +127,31 @@ impl WGPUContext {
         }
     }
 
+    pub fn extra_features(&self) -> Option<Features> {
+        self.extra_features
+    }
+
+    pub fn override_limits(&self) -> Option<Limits> {
+        self.override_limits.clone()
+    }
+
     /// Creates a new surface for the specified window and dimensions.
-    pub async fn create_surface<'w>(
+    pub fn create_surface<'w>(
+        &self,
+        window: impl Into<SurfaceTarget<'w>>,
+    ) -> Result<Surface<'w>, WgpuContextError> {
+        Ok(self.instance.create_surface(window.into())?)
+    }
+
+    /// Creates a new surface for the specified window and dimensions.
+    pub async fn create_surface_renderer<'w>(
         &mut self,
         window: impl Into<SurfaceTarget<'w>>,
         surface_config: SurfaceRendererConfiguration,
         intermediate_texture_config: Option<TextureConfiguration>,
     ) -> Result<SurfaceRenderer<'w>, WgpuContextError> {
         // Create a surface from the window handle
-        let surface = self.instance.create_surface(window.into())?;
+        let surface = self.create_surface(window.into())?;
 
         // Find or create a suitable device for rendering to the surface
         let dev_id = self
@@ -89,9 +165,7 @@ impl WGPUContext {
             surface_config,
             intermediate_texture_config,
             device_handle,
-            dev_id,
         )
-        .await
     }
 
     /// Creates a new `BufferRenderer` for the specified dimensions.
@@ -114,14 +188,23 @@ impl WGPUContext {
         &mut self,
         compatible_surface: Option<&Surface<'_>>,
     ) -> Result<usize, WgpuContextError> {
-        match self.find_existing_device(compatible_surface) {
+        match self.find_existing_device_idx(compatible_surface) {
             Some(device_id) => Ok(device_id),
             None => self.create_device(compatible_surface).await,
         }
     }
 
     /// Finds or creates a compatible device handle id.
-    fn find_existing_device(&self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
+    pub fn find_compatible_device_handle(
+        &mut self,
+        compatible_surface: Option<&Surface<'_>>,
+    ) -> Option<DeviceHandle> {
+        self.find_existing_device_idx(compatible_surface)
+            .map(|idx| self.device_pool[idx].clone())
+    }
+
+    /// Finds  a compatible device handle id.
+    fn find_existing_device_idx(&self, compatible_surface: Option<&Surface<'_>>) -> Option<usize> {
         match compatible_surface {
             Some(s) => self
                 .device_pool
@@ -133,47 +216,25 @@ impl WGPUContext {
         }
     }
 
+    pub fn create_device_handle(
+        &self,
+        compatible_surface: Option<&Surface<'_>>,
+    ) -> impl Future<Output = Result<DeviceHandle, WgpuContextError>> {
+        DeviceHandle::new_from_compatible_surface(
+            self.instance.clone(),
+            compatible_surface,
+            self.extra_features,
+            self.override_limits.clone(),
+        )
+    }
+
     /// Creates a compatible device handle id.
     async fn create_device(
         &mut self,
         compatible_surface: Option<&Surface<'_>>,
     ) -> Result<usize, WgpuContextError> {
-        let instance = self.instance.clone();
-        let adapter =
-            wgpu::util::initialize_adapter_from_env_or_default(&instance, compatible_surface)
-                .await?;
-
-        // Determine features to request
-        // The user may request additional features
-        let requested_features = self.extra_features.unwrap_or(Features::empty());
-        let available_features = adapter.features();
-        let required_features = requested_features & available_features;
-
-        // Determine limits to request
-        // The user may override the limits
-        let required_limits = self.override_limits.clone().unwrap_or_default();
-
-        // Create the device and the queue
-        let descripter = wgpu::DeviceDescriptor {
-            label: None,
-            required_features,
-            required_limits,
-            memory_hints: MemoryHints::MemoryUsage,
-            trace: wgpu::Trace::default(),
-            experimental_features: wgpu::ExperimentalFeatures::default(),
-        };
-        let (device, queue) = adapter.request_device(&descripter).await?;
-
-        // Create the device handle and store in the pool
-        let device_handle = DeviceHandle {
-            instance,
-            adapter,
-            device,
-            queue,
-        };
+        let device_handle = self.create_device_handle(compatible_surface).await?;
         self.device_pool.push(device_handle);
-
-        // Return the ID
         Ok(self.device_pool.len() - 1)
     }
 }

--- a/crates/wgpu_context/src/surface_renderer.rs
+++ b/crates/wgpu_context/src/surface_renderer.rs
@@ -79,7 +79,6 @@ struct IntermediateTextureStuff {
 /// Combination of surface and its configuration.
 pub struct SurfaceRenderer<'s> {
     // The device and queue for rendering to the surface
-    pub dev_id: usize,
     pub device_handle: DeviceHandle,
 
     // The surface and it's configuration
@@ -93,7 +92,6 @@ pub struct SurfaceRenderer<'s> {
 impl std::fmt::Debug for SurfaceRenderer<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SurfaceRenderer")
-            .field("dev_id", &self.dev_id)
             .field("surface_config", &self.config)
             .field("has_intermediate_texture", &true)
             .finish()
@@ -102,12 +100,11 @@ impl std::fmt::Debug for SurfaceRenderer<'_> {
 
 impl<'s> SurfaceRenderer<'s> {
     /// Creates a new render surface for the specified window and dimensions.
-    pub async fn new<'w>(
+    pub fn new<'w>(
         surface: Surface<'w>,
         surface_renderer_config: SurfaceRendererConfiguration,
         intermediate_texture_config: Option<TextureConfiguration>,
         device_handle: DeviceHandle,
-        dev_id: usize,
     ) -> Result<SurfaceRenderer<'w>, WgpuContextError> {
         // Convert SurfaceRendererConfiguration to SurfaceConfiguration.
         // The difference is that `format` is a Vec in SurfaceRendererConfiguration and a single value in SurfaceConfiguration
@@ -142,7 +139,6 @@ impl<'s> SurfaceRenderer<'s> {
         });
 
         let surface = SurfaceRenderer {
-            dev_id,
             device_handle,
             surface,
             config: surface_config,

--- a/examples/bunnymark/src/main.rs
+++ b/examples/bunnymark/src/main.rs
@@ -148,7 +148,13 @@ impl App {
         self.scale_factor = window.scale_factor();
 
         let physical_size = window.inner_size();
-        renderer.resume(window.clone(), physical_size.width, physical_size.height);
+        renderer.resume(
+            window.clone(),
+            physical_size.width,
+            physical_size.height,
+            || {},
+        );
+        let _ = renderer.complete_resume();
         self.render_state = RenderState::Active {
             window,
             renderer: f(renderer),

--- a/examples/player/src/main.rs
+++ b/examples/player/src/main.rs
@@ -140,7 +140,8 @@ impl App {
             Arc::new(event_loop.create_window(attr).unwrap())
         });
 
-        renderer.resume(window.clone(), self.width, self.height);
+        renderer.resume(window.clone(), self.width, self.height, || {});
+        let _ = renderer.complete_resume();
         let renderer = renderer.into();
         self.render_state = RenderState::Active { window, renderer };
         self.request_redraw();


### PR DESCRIPTION
Adds an async `resume_async` method to `WindowRenderer` so GPU backends can drive wgpu's fundamentally-async surface initialization without `pollster::block_on` deadlocking the JS event loop on `wasm32-unknown-unknown`. The default body forwards to sync `resume` (non-breaking for downstream impls); `anyrender_vello` and `anyrender_vello_hybrid` override it with a real async body and now `panic!` from sync `resume` on wasm32 instead of silently deadlocking.