### PR TITLE
Placeholders for cross origin iframes

### DIFF
--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -157,6 +157,9 @@ pub trait PaintScene {
         std_dev: f64,
     );
 
+    /// Marks a region where a separately produced iframe scene may be composited.
+    fn iframe_placeholder(&mut self, _frame_id: u64, _transform: Affine, _clip: &impl Shape) {}
+
     // --- Provided methods
 
     /// Append a recorded Scene Fragment to the current scene
@@ -218,6 +221,13 @@ pub trait PaintScene {
                     cmd.radius,
                     cmd.std_dev,
                 ),
+                RenderCommand::IframePlaceholder(cmd) => {
+                    self.iframe_placeholder(
+                        cmd.frame_id,
+                        scene_transform * cmd.transform,
+                        &cmd.clip,
+                    )
+                }
             }
         }
     }

--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -41,7 +41,7 @@ pub use types::*;
 mod null_backend;
 pub use null_backend::*;
 pub mod recording;
-pub use recording::Scene;
+pub use recording::{PlaceholderCommand, PlaceholderKind, Scene};
 
 #[cfg(feature = "serde")]
 mod svg_path_parser;
@@ -157,8 +157,8 @@ pub trait PaintScene {
         std_dev: f64,
     );
 
-    /// Marks a region where a separately produced iframe scene may be composited.
-    fn iframe_placeholder(&mut self, _frame_id: u64, _transform: Affine, _clip: &impl Shape) {}
+    /// Marks a region where a separately produced scene may be composited.
+    fn placeholder(&mut self, _kind: PlaceholderKind, _transform: Affine, _clip: &impl Shape) {}
 
     // --- Provided methods
 
@@ -221,12 +221,8 @@ pub trait PaintScene {
                     cmd.radius,
                     cmd.std_dev,
                 ),
-                RenderCommand::IframePlaceholder(cmd) => {
-                    self.iframe_placeholder(
-                        cmd.frame_id,
-                        scene_transform * cmd.transform,
-                        &cmd.clip,
-                    )
+                RenderCommand::Placeholder(cmd) => {
+                    self.placeholder(cmd.kind, scene_transform * cmd.transform, &cmd.clip)
                 }
             }
         }

--- a/crates/anyrender/src/recording.rs
+++ b/crates/anyrender/src/recording.rs
@@ -28,6 +28,8 @@ pub enum RenderCommand<Font = FontData, Image = ImageData> {
     GlyphRun(GlyphRunCommand<Font, Image>),
     /// Draw a rounded rectangle blurred with a gaussian filter.
     BoxShadow(BoxShadowCommand),
+    /// Marks a region where a separately produced iframe scene may be composited.
+    IframePlaceholder(IframePlaceholderCommand),
 }
 
 impl RenderCommand {
@@ -41,6 +43,7 @@ impl RenderCommand {
             RenderCommand::Fill(cmd) => cmd.transform = transform * cmd.transform,
             RenderCommand::GlyphRun(cmd) => cmd.transform = transform * cmd.transform,
             RenderCommand::BoxShadow(cmd) => cmd.transform = transform * cmd.transform,
+            RenderCommand::IframePlaceholder(cmd) => cmd.transform = transform * cmd.transform,
         };
 
         self
@@ -120,6 +123,16 @@ pub struct BoxShadowCommand {
     pub brush: Color,
     pub radius: f64,
     pub std_dev: f64,
+}
+
+/// Marks a region where a separately produced iframe scene may be composited.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct IframePlaceholderCommand {
+    pub frame_id: u64,
+    pub transform: Affine,
+    #[cfg_attr(feature = "serde", serde(with = "svg_path"))]
+    pub clip: BezPath,
 }
 
 /// A recording of a Scene or Scene Fragment stored as plain data types that can be stored
@@ -281,6 +294,16 @@ impl PaintScene for Scene {
             std_dev,
         };
         self.commands.push(RenderCommand::BoxShadow(box_shadow));
+    }
+
+    fn iframe_placeholder(&mut self, frame_id: u64, transform: Affine, clip: &impl Shape) {
+        let clip = clip.into_path(self.tolerance);
+        let placeholder = IframePlaceholderCommand {
+            frame_id,
+            transform,
+            clip,
+        };
+        self.commands.push(RenderCommand::IframePlaceholder(placeholder));
     }
 
     fn append_scene(&mut self, scene: Scene, scene_transform: Affine) {

--- a/crates/anyrender/src/recording.rs
+++ b/crates/anyrender/src/recording.rs
@@ -28,8 +28,8 @@ pub enum RenderCommand<Font = FontData, Image = ImageData> {
     GlyphRun(GlyphRunCommand<Font, Image>),
     /// Draw a rounded rectangle blurred with a gaussian filter.
     BoxShadow(BoxShadowCommand),
-    /// Marks a region where a separately produced iframe scene may be composited.
-    IframePlaceholder(IframePlaceholderCommand),
+    /// Marks a region where a separately produced scene may be composited.
+    Placeholder(PlaceholderCommand),
 }
 
 impl RenderCommand {
@@ -43,7 +43,7 @@ impl RenderCommand {
             RenderCommand::Fill(cmd) => cmd.transform = transform * cmd.transform,
             RenderCommand::GlyphRun(cmd) => cmd.transform = transform * cmd.transform,
             RenderCommand::BoxShadow(cmd) => cmd.transform = transform * cmd.transform,
-            RenderCommand::IframePlaceholder(cmd) => cmd.transform = transform * cmd.transform,
+            RenderCommand::Placeholder(cmd) => cmd.transform = transform * cmd.transform,
         };
 
         self
@@ -125,11 +125,18 @@ pub struct BoxShadowCommand {
     pub std_dev: f64,
 }
 
-/// Marks a region where a separately produced iframe scene may be composited.
+/// Identifies the out-of-band scene content that should be composited into a placeholder region.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct IframePlaceholderCommand {
-    pub frame_id: u64,
+pub enum PlaceholderKind {
+    CrossOriginIframe { frame_id: u64 },
+}
+
+/// Marks a region where a separately produced scene may be composited.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct PlaceholderCommand {
+    pub kind: PlaceholderKind,
     pub transform: Affine,
     #[cfg_attr(feature = "serde", serde(with = "svg_path"))]
     pub clip: BezPath,
@@ -296,14 +303,14 @@ impl PaintScene for Scene {
         self.commands.push(RenderCommand::BoxShadow(box_shadow));
     }
 
-    fn iframe_placeholder(&mut self, frame_id: u64, transform: Affine, clip: &impl Shape) {
+    fn placeholder(&mut self, kind: PlaceholderKind, transform: Affine, clip: &impl Shape) {
         let clip = clip.into_path(self.tolerance);
-        let placeholder = IframePlaceholderCommand {
-            frame_id,
+        let placeholder = PlaceholderCommand {
+            kind,
             transform,
             clip,
         };
-        self.commands.push(RenderCommand::IframePlaceholder(placeholder));
+        self.commands.push(RenderCommand::Placeholder(placeholder));
     }
 
     fn append_scene(&mut self, scene: Scene, scene_transform: Affine) {


### PR DESCRIPTION
Introduce a general placeholder concept that can be used by a compositor to support cross origin iframes(running in a separate process), but later potentially other things (like video that would run in a separate process from where the video element is found, or an offscreen canvas running in a worker). 