### PR TITLE
Pick best supported alpha composite mode from surface

### DIFF
--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -226,6 +226,15 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                 .expect("Error creating DeviceHandle"),
             };
 
+            let surface_capabilities = surface.get_capabilities(&device_handle.adapter);
+
+            let alpha_mode = surface_capabilities
+                .alpha_modes
+                .iter()
+                .copied()
+                .max_by_key(|mode| *mode as usize)
+                .unwrap_or_default();
+
             let render_surface = SurfaceRenderer::new(
                 surface,
                 SurfaceRendererConfiguration {
@@ -235,7 +244,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                     height,
                     present_mode: PresentMode::AutoVsync,
                     desired_maximum_frame_latency: 2,
-                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    alpha_mode,
                     view_formats: vec![],
                 },
                 None,


### PR DESCRIPTION
Previously, the alpha composite mode was always set to auto, which only picks between `Opaque` and `Inherit`,
but on Wayland (and possibly other platforms), the surface only supports `Opaque` and `PreMultiplied`,
so transparent windows would never work.

This is very lazy way to query the surface capabilities for the highest supported alpha mode, which will pick the first of, in order,
`Inherit`, `PostMultiplied`, `PreMultiplied`, `Opaque`, or `Auto` (according to the enum)
