### PR TITLE
Support Configurable Composite Alpha Modes, Transparency, & Renderer Options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,6 +3204,7 @@ version = "0.6.0"
 dependencies = [
  "anyrender",
  "debug_timer",
+ "peniko",
  "softbuffer",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,6 +3204,7 @@ version = "0.6.0"
 dependencies = [
  "anyrender",
  "debug_timer",
+ "kurbo",
  "peniko",
  "softbuffer",
 ]

--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -148,10 +148,6 @@ pub trait WindowRenderer: RenderContext {
     fn is_pending(&self) -> bool {
         false
     }
-
-    /// Returns the composite alpha mode currently being used by this renderer
-    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode>;
-
     fn set_size(&mut self, width: u32, height: u32);
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F);
 }

--- a/crates/anyrender/src/lib.rs
+++ b/crates/anyrender/src/lib.rs
@@ -149,6 +149,9 @@ pub trait WindowRenderer: RenderContext {
         false
     }
 
+    /// Returns the composite alpha mode currently being used by this renderer
+    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode>;
+
     fn set_size(&mut self, width: u32, height: u32);
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F);
 }

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -1,9 +1,6 @@
 //! A dummy implementation of the AnyRender traits while simply ignores all commands
 
-use crate::{
-    CurrentCompositeAlphaMode, Filter, ImageRenderer, PaintScene, RenderContext, WindowHandle,
-    WindowRenderer,
-};
+use crate::{Filter, ImageRenderer, PaintScene, RenderContext, WindowHandle, WindowRenderer};
 use std::sync::Arc;
 
 #[derive(Copy, Clone, Default)]
@@ -49,9 +46,9 @@ impl WindowRenderer for NullWindowRenderer {
 
     fn set_size(&mut self, _width: u32, _height: u32) {}
 
-    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
-        Some(CurrentCompositeAlphaMode::Opaque)
-    }
+    // fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
+    //     Some(CurrentCompositeAlphaMode::Opaque)
+    // }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, _draw_fn: F) {}
 }

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -1,6 +1,9 @@
 //! A dummy implementation of the AnyRender traits while simply ignores all commands
 
-use crate::{Filter, ImageRenderer, PaintScene, RenderContext, WindowHandle, WindowRenderer};
+use crate::{
+    CurrentCompositeAlphaMode, Filter, ImageRenderer, PaintScene, RenderContext, WindowHandle,
+    WindowRenderer,
+};
 use std::sync::Arc;
 
 #[derive(Copy, Clone, Default)]
@@ -45,6 +48,10 @@ impl WindowRenderer for NullWindowRenderer {
     }
 
     fn set_size(&mut self, _width: u32, _height: u32) {}
+
+    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
+        Some(CurrentCompositeAlphaMode::Opaque)
+    }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, _draw_fn: F) {}
 }

--- a/crates/anyrender/src/null_backend.rs
+++ b/crates/anyrender/src/null_backend.rs
@@ -46,10 +46,6 @@ impl WindowRenderer for NullWindowRenderer {
 
     fn set_size(&mut self, _width: u32, _height: u32) {}
 
-    // fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
-    //     Some(CurrentCompositeAlphaMode::Opaque)
-    // }
-
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, _draw_fn: F) {}
 }
 

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -131,9 +131,7 @@ pub enum CompositeAlphaMode {
     #[default]
     Auto,
     Opaque,
-    PreMultiplied,
-    PostMultiplied,
-    Inherit,
+    Transparent,
 }
 
 /// Error returned when converting a unified configuration to a backend-specific one.

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -123,3 +123,69 @@ impl<'a> From<BrushRef<'a>> for PaintRef<'a> {
         }
     }
 }
+
+/// Alpha mode used when compositing the window surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum CompositeAlphaMode {
+    #[default]
+    Auto,
+    Opaque,
+    PreMultiplied,
+    PostMultiplied,
+    Inherit,
+}
+
+/// Error returned when converting a unified configuration to a backend-specific one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    /// The target renderer does not support this configuration option.
+    UnsupportedField(&'static str),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedField(field) => write!(f, "unsupported configuration field: {field}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+/// Unified renderer configuration options.
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub struct RendererConfig {
+    /// Background color used to clear the frame.
+    pub base_color: Option<Color>,
+    /// Alpha mode used when compositing the window surface.
+    pub composite_alpha_mode: Option<CompositeAlphaMode>,
+}
+
+impl RendererConfig {
+    /// Create a new configuration with default (None) values.
+    pub const fn new() -> Self {
+        Self {
+            base_color: None,
+            composite_alpha_mode: None,
+        }
+    }
+
+    /// Set the background color.
+    pub const fn base_color(self, base_color: Color) -> Self {
+        Self {
+            base_color: Some(base_color),
+            ..self
+        }
+    }
+
+    /// Set the composite alpha mode.
+    pub const fn composite_alpha_mode(self, mode: CompositeAlphaMode) -> Self {
+        Self {
+            composite_alpha_mode: Some(mode),
+            ..self
+        }
+    }
+}

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -134,23 +134,6 @@ pub enum CompositeAlphaMode {
     Transparent,
 }
 
-/// Error returned when converting a unified configuration to a backend-specific one.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ConfigError {
-    /// The target renderer does not support this configuration option.
-    UnsupportedField(&'static str),
-}
-
-impl std::fmt::Display for ConfigError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnsupportedField(field) => write!(f, "unsupported configuration field: {field}"),
-        }
-    }
-}
-
-impl std::error::Error for ConfigError {}
-
 /// Unified renderer configuration options.
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -134,6 +134,28 @@ pub enum CompositeAlphaMode {
     Transparent,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(u8)]
+pub enum CurrentCompositeAlphaMode {
+    PreMultiplied = 0,
+    PostMultiplied = 1,
+    Opaque = 2,
+}
+
+impl TryFrom<u8> for CurrentCompositeAlphaMode {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::PreMultiplied),
+            1 => Ok(Self::PostMultiplied),
+            2 => Ok(Self::Opaque),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Error returned when converting a unified configuration to a backend-specific one.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigError {

--- a/crates/anyrender/src/types.rs
+++ b/crates/anyrender/src/types.rs
@@ -134,28 +134,6 @@ pub enum CompositeAlphaMode {
     Transparent,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[repr(u8)]
-pub enum CurrentCompositeAlphaMode {
-    PreMultiplied = 0,
-    PostMultiplied = 1,
-    Opaque = 2,
-}
-
-impl TryFrom<u8> for CurrentCompositeAlphaMode {
-    type Error = ();
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::PreMultiplied),
-            1 => Ok(Self::PostMultiplied),
-            2 => Ok(Self::Opaque),
-            _ => Err(()),
-        }
-    }
-}
-
 /// Error returned when converting a unified configuration to a backend-specific one.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfigError {

--- a/crates/anyrender_skia/src/image_renderer.rs
+++ b/crates/anyrender_skia/src/image_renderer.rs
@@ -62,7 +62,7 @@ impl ImageRenderer for SkiaImageRenderer {
         )
         .unwrap();
 
-        surface.canvas().clear(Color::WHITE);
+        surface.canvas().clear(Color::TRANSPARENT);
 
         draw_fn(&mut SkiaScenePainter {
             inner: surface.canvas(),
@@ -87,7 +87,7 @@ impl ImageRenderer for SkiaImageRenderer {
         )
         .unwrap();
 
-        surface.canvas().clear(Color::WHITE);
+        surface.canvas().clear(Color::TRANSPARENT);
 
         draw_fn(&mut SkiaScenePainter {
             inner: surface.canvas(),

--- a/crates/anyrender_skia/src/image_renderer.rs
+++ b/crates/anyrender_skia/src/image_renderer.rs
@@ -62,6 +62,7 @@ impl ImageRenderer for SkiaImageRenderer {
         )
         .unwrap();
 
+        // Clear surface with transparent background to allow transparency in rendered images
         surface.canvas().clear(Color::TRANSPARENT);
 
         draw_fn(&mut SkiaScenePainter {
@@ -87,6 +88,7 @@ impl ImageRenderer for SkiaImageRenderer {
         )
         .unwrap();
 
+        // Clear surface with transparent background to allow transparency in rendered images
         surface.canvas().clear(Color::TRANSPARENT);
 
         draw_fn(&mut SkiaScenePainter {

--- a/crates/anyrender_skia/src/metal.rs
+++ b/crates/anyrender_skia/src/metal.rs
@@ -24,13 +24,22 @@ pub struct MetalBackend {
 }
 
 impl MetalBackend {
-    pub fn new(window: Arc<dyn anyrender::WindowHandle>, width: u32, height: u32) -> Self {
+    pub fn new(
+        window: Arc<dyn anyrender::WindowHandle>,
+        width: u32,
+        height: u32,
+        composite_alpha_mode: anyrender::CompositeAlphaMode,
+    ) -> Self {
         let device = MTLCreateSystemDefaultDevice().expect("no device found");
 
         let metal_layer = {
             let layer = CAMetalLayer::new();
             layer.setDevice(Some(&device));
             layer.setPixelFormat(objc2_metal::MTLPixelFormat::BGRA8Unorm);
+            layer.setOpaque(matches!(
+                composite_alpha_mode,
+                anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto
+            ));
             layer.setPresentsWithTransaction(false);
             // Disabling this option allows Skia's Blend Mode to work.
             // More about: https://developer.apple.com/documentation/quartzcore/cametallayer/1478168-framebufferonly

--- a/crates/anyrender_skia/src/opengl.rs
+++ b/crates/anyrender_skia/src/opengl.rs
@@ -53,21 +53,43 @@ impl OpenGLBackend {
             composite_alpha_mode,
             anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto
         );
-        let gl_config_template = ConfigTemplateBuilder::new()
-            .with_transparency(transparency)
-            .build();
+        let mut template = ConfigTemplateBuilder::new().with_transparency(transparency);
+        if transparency {
+            template = template.with_alpha_size(8);
+        } else {
+            template = template.with_alpha_size(0);
+        }
+        let gl_config_template = template.build();
+
         let gl_config = unsafe {
             gl_display
                 .find_configs(gl_config_template)
                 .unwrap()
                 .reduce(|accum, config| {
-                    let transparency_check = config.supports_transparency().unwrap_or(false)
-                        & !accum.supports_transparency().unwrap_or(false);
+                    let config_transparency = config.supports_transparency().unwrap_or(false);
+                    let accum_transparency = accum.supports_transparency().unwrap_or(false);
 
-                    if transparency_check || config.num_samples() < accum.num_samples() {
+                    if config_transparency == transparency && accum_transparency != transparency {
                         config
-                    } else {
+                    } else if accum_transparency == transparency
+                        && config_transparency != transparency
+                    {
                         accum
+                    } else {
+                        let config_alpha = config.alpha_size();
+                        let accum_alpha = accum.alpha_size();
+                        if config_alpha != accum_alpha {
+                            let prefer_config = if transparency {
+                                config_alpha > accum_alpha
+                            } else {
+                                config_alpha < accum_alpha
+                            };
+                            if prefer_config { config } else { accum }
+                        } else if config.num_samples() < accum.num_samples() {
+                            config
+                        } else {
+                            accum
+                        }
                     }
                 })
                 .unwrap()

--- a/crates/anyrender_skia/src/opengl.rs
+++ b/crates/anyrender_skia/src/opengl.rs
@@ -31,6 +31,7 @@ impl OpenGLBackend {
         window: Arc<dyn anyrender::WindowHandle>,
         width: u32,
         height: u32,
+        composite_alpha_mode: anyrender::CompositeAlphaMode,
     ) -> OpenGLBackend {
         let raw_display_handle = window.display_handle().unwrap().as_raw();
         let raw_window_handle = window.window_handle().unwrap().as_raw();
@@ -48,7 +49,13 @@ impl OpenGLBackend {
             .unwrap()
         };
 
-        let gl_config_template = ConfigTemplateBuilder::new().with_transparency(true).build();
+        let transparency = !matches!(
+            composite_alpha_mode,
+            anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto
+        );
+        let gl_config_template = ConfigTemplateBuilder::new()
+            .with_transparency(transparency)
+            .build();
         let gl_config = unsafe {
             gl_display
                 .find_configs(gl_config_template)

--- a/crates/anyrender_skia/src/vulkan.rs
+++ b/crates/anyrender_skia/src/vulkan.rs
@@ -1,3 +1,5 @@
+use crate::window_renderer::SkiaBackend;
+use anyrender::{CompositeAlphaMode, CurrentCompositeAlphaMode};
 use ash::{
     Device, Entry, Instance,
     vk::{
@@ -35,8 +37,6 @@ use std::{
     sync::Arc,
 };
 
-use crate::window_renderer::SkiaBackend;
-
 pub(crate) struct VulkanBackend {
     _entry: Entry, // Dont drop until backend is dropped
     instance: Instance,
@@ -61,6 +61,7 @@ pub(crate) struct VulkanBackend {
     cmd_pool: CommandPool,
     cmd_buf: CommandBuffer,
     composite_alpha_mode: anyrender::CompositeAlphaMode,
+    current_alpha_mode: CompositeAlphaFlagsKHR,
 }
 
 impl VulkanBackend {
@@ -93,18 +94,24 @@ impl VulkanBackend {
 
         let swapchain_size = (width, height);
 
-        let (swapchain, swapchain_fns, swapchain_images, swapchain_format, swapchain_extent) =
-            create_swapchain(
-                &instance,
-                &device,
-                physical_device,
-                &surface_fns,
-                surface,
-                queue_family_index,
-                swapchain_size,
-                composite_alpha_mode,
-                None,
-            );
+        let (
+            swapchain,
+            swapchain_fns,
+            swapchain_images,
+            swapchain_format,
+            swapchain_extent,
+            chosen_alpha_mode,
+        ) = create_swapchain(
+            &instance,
+            &device,
+            physical_device,
+            &surface_fns,
+            surface,
+            queue_family_index,
+            swapchain_size,
+            composite_alpha_mode,
+            None,
+        );
 
         let gr_context = create_gr_context(
             &entry,
@@ -165,6 +172,7 @@ impl VulkanBackend {
             cmd_pool,
             cmd_buf,
             composite_alpha_mode,
+            current_alpha_mode: chosen_alpha_mode,
         }
     }
 
@@ -175,27 +183,44 @@ impl VulkanBackend {
 
         let old_swapchain = self.swapchain;
 
-        let (swapchain, swapchain_fns, swapchain_images, swapchain_format, swapchain_extent) =
-            create_swapchain(
-                &self.instance,
-                &self.device,
-                self.physical_device,
-                &self.surface_fns,
-                self.surface,
-                self.queue_family_index,
-                self.swapchain_size,
-                self.composite_alpha_mode,
-                Some(old_swapchain),
-            );
+        let (
+            swapchain,
+            swapchain_fns,
+            swapchain_images,
+            swapchain_format,
+            swapchain_extent,
+            current_alpha_mode,
+        ) = create_swapchain(
+            &self.instance,
+            &self.device,
+            self.physical_device,
+            &self.surface_fns,
+            self.surface,
+            self.queue_family_index,
+            self.swapchain_size,
+            self.composite_alpha_mode,
+            Some(old_swapchain),
+        );
         self.swapchain = swapchain;
         self.swapchain_fns = swapchain_fns;
         self.swapchain_images = swapchain_images;
         self.swapchain_format = swapchain_format;
         self.swapchain_extent = swapchain_extent;
         self.swapchain_suboptimal = false;
+        self.current_alpha_mode = current_alpha_mode;
 
         unsafe {
             self.swapchain_fns.destroy_swapchain(old_swapchain, None);
+        }
+    }
+
+    pub(crate) fn current_alpha_mode(&self) -> CurrentCompositeAlphaMode {
+        match self.current_alpha_mode {
+            CompositeAlphaFlagsKHR::OPAQUE => CurrentCompositeAlphaMode::Opaque,
+            CompositeAlphaFlagsKHR::PRE_MULTIPLIED => CurrentCompositeAlphaMode::PreMultiplied,
+            CompositeAlphaFlagsKHR::POST_MULTIPLIED => CurrentCompositeAlphaMode::PostMultiplied,
+            CompositeAlphaFlagsKHR::INHERIT => CurrentCompositeAlphaMode::Opaque,
+            _ => CurrentCompositeAlphaMode::Opaque,
         }
     }
 }
@@ -481,6 +506,7 @@ fn create_swapchain(
     Vec<Image>,
     Format,
     Extent2D,
+    CompositeAlphaFlagsKHR,
 ) {
     let surface_caps = unsafe {
         surface_fns
@@ -542,6 +568,11 @@ fn create_swapchain(
         {
             CompositeAlphaFlagsKHR::PRE_MULTIPLIED
         }
+        anyrender::CompositeAlphaMode::Transparent
+            if supported.contains(CompositeAlphaFlagsKHR::POST_MULTIPLIED) =>
+        {
+            CompositeAlphaFlagsKHR::POST_MULTIPLIED
+        }
         _ => {
             if supported.contains(CompositeAlphaFlagsKHR::OPAQUE) {
                 CompositeAlphaFlagsKHR::OPAQUE
@@ -582,7 +613,14 @@ fn create_swapchain(
     let swapchain = unsafe { swapchain_fns.create_swapchain(&create_info, None).unwrap() };
     let images = unsafe { swapchain_fns.get_swapchain_images(swapchain).unwrap() };
 
-    (swapchain, swapchain_fns, images, format.format, extent)
+    (
+        swapchain,
+        swapchain_fns,
+        images,
+        format.format,
+        extent,
+        composite_alpha,
+    )
 }
 
 fn create_gr_context(

--- a/crates/anyrender_skia/src/vulkan.rs
+++ b/crates/anyrender_skia/src/vulkan.rs
@@ -537,20 +537,10 @@ fn create_swapchain(
         {
             CompositeAlphaFlagsKHR::OPAQUE
         }
-        anyrender::CompositeAlphaMode::PreMultiplied
+        anyrender::CompositeAlphaMode::Transparent
             if supported.contains(CompositeAlphaFlagsKHR::PRE_MULTIPLIED) =>
         {
             CompositeAlphaFlagsKHR::PRE_MULTIPLIED
-        }
-        anyrender::CompositeAlphaMode::PostMultiplied
-            if supported.contains(CompositeAlphaFlagsKHR::POST_MULTIPLIED) =>
-        {
-            CompositeAlphaFlagsKHR::POST_MULTIPLIED
-        }
-        anyrender::CompositeAlphaMode::Inherit
-            if supported.contains(CompositeAlphaFlagsKHR::INHERIT) =>
-        {
-            CompositeAlphaFlagsKHR::INHERIT
         }
         _ => {
             if supported.contains(CompositeAlphaFlagsKHR::OPAQUE) {

--- a/crates/anyrender_skia/src/vulkan.rs
+++ b/crates/anyrender_skia/src/vulkan.rs
@@ -1,5 +1,4 @@
 use crate::window_renderer::SkiaBackend;
-use anyrender::{CompositeAlphaMode, CurrentCompositeAlphaMode};
 use ash::{
     Device, Entry, Instance,
     vk::{
@@ -26,12 +25,22 @@ use ash::{
 use ash_window::enumerate_required_extensions;
 use raw_window_handle::DisplayHandle;
 use skia_safe::{
-    Surface,
+    BlendMode, Paint, RuntimeEffect, Surface,
     gpu::{
         ContextOptions, DirectContext, backend_render_targets, direct_contexts, surfaces,
         vk::{Alloc, BackendContext, GetProcOf, Version},
     },
 };
+
+const UNPREMULTIPLY_SKSL: &str = r#"
+    uniform shader input_texture;
+
+    half4 main(float2 coords) {
+        half4 color = input_texture.eval(coords);
+        color.rgb = color.rgb / max(color.a, 0.0001);
+        return color;
+    }
+"#;
 use std::{
     ffi::{CStr, CString},
     sync::Arc,
@@ -62,6 +71,8 @@ pub(crate) struct VulkanBackend {
     cmd_buf: CommandBuffer,
     composite_alpha_mode: anyrender::CompositeAlphaMode,
     current_alpha_mode: CompositeAlphaFlagsKHR,
+    unpremul_effect: skia_safe::RuntimeEffect,
+    intermediate_surface: Option<skia_safe::Surface>,
 }
 
 impl VulkanBackend {
@@ -148,6 +159,9 @@ impl VulkanBackend {
                 .unwrap()[0]
         };
 
+        let unpremul_effect = RuntimeEffect::make_for_shader(UNPREMULTIPLY_SKSL, None)
+            .expect("Failed to compile SkSL unpremultiply shader");
+
         Self {
             _entry: entry,
             instance,
@@ -173,6 +187,8 @@ impl VulkanBackend {
             cmd_buf,
             composite_alpha_mode,
             current_alpha_mode: chosen_alpha_mode,
+            unpremul_effect,
+            intermediate_surface: None,
         }
     }
 
@@ -208,20 +224,158 @@ impl VulkanBackend {
         self.swapchain_extent = swapchain_extent;
         self.swapchain_suboptimal = false;
         self.current_alpha_mode = current_alpha_mode;
+        self.intermediate_surface = None;
 
         unsafe {
             self.swapchain_fns.destroy_swapchain(old_swapchain, None);
         }
     }
 
-    pub(crate) fn current_alpha_mode(&self) -> CurrentCompositeAlphaMode {
-        match self.current_alpha_mode {
-            CompositeAlphaFlagsKHR::OPAQUE => CurrentCompositeAlphaMode::Opaque,
-            CompositeAlphaFlagsKHR::PRE_MULTIPLIED => CurrentCompositeAlphaMode::PreMultiplied,
-            CompositeAlphaFlagsKHR::POST_MULTIPLIED => CurrentCompositeAlphaMode::PostMultiplied,
-            CompositeAlphaFlagsKHR::INHERIT => CurrentCompositeAlphaMode::Opaque,
-            _ => CurrentCompositeAlphaMode::Opaque,
+    /// Prepares a Skia-allocated intermediate surface.
+    ///
+    /// Unlike the swapchain image, this offscreen surface is fully managed and allocated
+    /// by Skia on the GPU (the context is managed entirely by Skia). We only specify the
+    /// high-level image info, and Skia takes care of creating the underlying Vulkan image
+    /// and allocating its GPU memory.
+    fn prepare_intermediate_surface(&mut self) -> Surface {
+        let width = self.swapchain_extent.width;
+        let height = self.swapchain_extent.height;
+
+        let needs_recreate = self
+            .intermediate_surface
+            .as_ref()
+            .map(|s| s.width() != width as i32 || s.height() != height as i32)
+            .unwrap_or(true);
+
+        if needs_recreate {
+            let image_info = skia_safe::ImageInfo::new(
+                (width as i32, height as i32),
+                skia_safe::ColorType::BGRA8888,
+                skia_safe::AlphaType::Premul,
+                None,
+            );
+            self.intermediate_surface = surfaces::render_target(
+                &mut self.gr_context,
+                skia_safe::gpu::Budgeted::No,
+                &image_info,
+                None,
+                skia_safe::gpu::SurfaceOrigin::TopLeft,
+                None,
+                None,
+                None,
+            );
         }
+
+        self.intermediate_surface.clone().unwrap()
+    }
+
+    /// Prepares a Skia surface that wraps the raw Vulkan swapchain image.
+    ///
+    /// Since the swapchain image is allocated and owned by Vulkan/the OS window system,
+    /// we must describe its layout and format details so Skia can wrap and draw to it.
+    ///
+    /// NOTE: We wrap the swapchain image on-the-fly every frame instead of caching the
+    /// wrapped surfaces. Caching is unsafe because the queue presentation transitions the
+    /// Vulkan image layout to PRESENT_SRC_KHR outside of Skia's control, which would cause
+    /// Skia's internal layout tracking to go out of sync.
+    unsafe fn prepare_swapchain_surface(&mut self, image_index: u32) -> Surface {
+        let image = self.swapchain_images[image_index as usize];
+
+        unsafe {
+            let alloc = Alloc::default();
+            let sk_image_info = skia_safe::gpu::vk::ImageInfo::new(
+                image.as_raw() as _,
+                alloc,
+                skia_safe::gpu::vk::ImageTiling::OPTIMAL,
+                skia_safe::gpu::vk::ImageLayout::UNDEFINED,
+                skia_safe::gpu::vk::Format::B8G8R8A8_UNORM,
+                1,
+                None,
+                None,
+                None,
+                skia_safe::gpu::vk::SharingMode::EXCLUSIVE,
+            );
+            let render_target = backend_render_targets::make_vk(
+                (
+                    self.swapchain_extent.width as i32,
+                    self.swapchain_extent.height as i32,
+                ),
+                &sk_image_info,
+            );
+
+            surfaces::wrap_backend_render_target(
+                &mut self.gr_context,
+                &render_target,
+                skia_safe::gpu::SurfaceOrigin::TopLeft,
+                skia_safe::ColorType::BGRA8888,
+                None,
+                None,
+            )
+            .unwrap()
+        }
+    }
+
+    /// Performs the post-processing blit when compositing in POST_MULTIPLIED alpha mode.
+    ///
+    /// The intermediate surface is snapshotted and drawn onto a wrapped surface representing
+    /// the Vulkan swapchain image, executing the unpremultiply shader in the process.
+    fn flush_post_multiplied(&mut self, surface: &mut Surface) {
+        let image = self.swapchain_images[self.swapchain_image_index as usize];
+
+        // NOTE: Wrapping is a zero-copy CPU metadata operation (extremely cheap). Wrapping on-the-fly
+        // every frame is required to ensure Skia's internal layout tracking remains in sync with the
+        // manual queue presentation layout transitions.
+        let mut swapchain_surface = unsafe {
+            let alloc = Alloc::default();
+            let sk_image_info = skia_safe::gpu::vk::ImageInfo::new(
+                image.as_raw() as _,
+                alloc,
+                skia_safe::gpu::vk::ImageTiling::OPTIMAL,
+                skia_safe::gpu::vk::ImageLayout::UNDEFINED,
+                skia_safe::gpu::vk::Format::B8G8R8A8_UNORM,
+                1,
+                None,
+                None,
+                None,
+                skia_safe::gpu::vk::SharingMode::EXCLUSIVE,
+            );
+            let render_target = backend_render_targets::make_vk(
+                (
+                    self.swapchain_extent.width as i32,
+                    self.swapchain_extent.height as i32,
+                ),
+                &sk_image_info,
+            );
+
+            surfaces::wrap_backend_render_target(
+                &mut self.gr_context,
+                &render_target,
+                skia_safe::gpu::SurfaceOrigin::TopLeft,
+                skia_safe::ColorType::BGRA8888,
+                None,
+                None,
+            )
+            .unwrap()
+        };
+
+        let image_snapshot = surface.image_snapshot();
+        let image_shader = image_snapshot
+            .to_shader(None, skia_safe::SamplingOptions::default(), None)
+            .unwrap();
+
+        let children = [skia_safe::runtime_effect::ChildPtr::from(image_shader)];
+        let unpremul_shader = self
+            .unpremul_effect
+            .make_shader(skia_safe::Data::new_empty(), &children, None)
+            .unwrap();
+
+        let mut paint = Paint::default();
+        paint.set_shader(unpremul_shader);
+        paint.set_blend_mode(BlendMode::Src);
+
+        swapchain_surface.canvas().draw_paint(&paint);
+
+        self.gr_context.flush_and_submit();
     }
 }
 
@@ -229,6 +383,8 @@ impl Drop for VulkanBackend {
     fn drop(&mut self) {
         unsafe {
             self.device.device_wait_idle().unwrap();
+
+            self.intermediate_surface = None;
 
             self.device
                 .free_command_buffers(self.cmd_pool, std::slice::from_ref(&self.cmd_buf));
@@ -278,45 +434,22 @@ impl SkiaBackend for VulkanBackend {
             self.swapchain_image_index = image_index;
             self.swapchain_suboptimal = suboptimal;
 
-            let image = self.swapchain_images[image_index as usize];
-
-            let alloc = Alloc::default();
-            let sk_image_info = skia_safe::gpu::vk::ImageInfo::new(
-                image.as_raw() as _,
-                alloc,
-                skia_safe::gpu::vk::ImageTiling::OPTIMAL,
-                skia_safe::gpu::vk::ImageLayout::UNDEFINED,
-                skia_safe::gpu::vk::Format::B8G8R8A8_UNORM,
-                1,
-                None,
-                None,
-                None,
-                skia_safe::gpu::vk::SharingMode::EXCLUSIVE,
-            );
-            let render_target = backend_render_targets::make_vk(
-                (
-                    self.swapchain_extent.width as i32,
-                    self.swapchain_extent.height as i32,
-                ),
-                &sk_image_info,
-            );
-
-            surfaces::wrap_backend_render_target(
-                &mut self.gr_context,
-                &render_target,
-                skia_safe::gpu::SurfaceOrigin::TopLeft,
-                skia_safe::ColorType::BGRA8888,
-                None,
-                None,
-            )
-            .unwrap()
+            if self.current_alpha_mode == CompositeAlphaFlagsKHR::POST_MULTIPLIED {
+                self.prepare_intermediate_surface()
+            } else {
+                self.prepare_swapchain_surface(image_index)
+            }
         };
 
         Some(surface)
     }
 
-    fn flush(&mut self, surface: Surface) {
-        self.gr_context.flush_and_submit();
+    fn flush(&mut self, mut surface: Surface) {
+        if self.current_alpha_mode == CompositeAlphaFlagsKHR::POST_MULTIPLIED {
+            self.flush_post_multiplied(&mut surface);
+        } else {
+            self.gr_context.flush_and_submit();
+        }
 
         let image = self.swapchain_images[self.swapchain_image_index as usize];
 

--- a/crates/anyrender_skia/src/vulkan.rs
+++ b/crates/anyrender_skia/src/vulkan.rs
@@ -60,6 +60,7 @@ pub(crate) struct VulkanBackend {
     in_flight_fence: Fence,
     cmd_pool: CommandPool,
     cmd_buf: CommandBuffer,
+    composite_alpha_mode: anyrender::CompositeAlphaMode,
 }
 
 impl VulkanBackend {
@@ -67,6 +68,7 @@ impl VulkanBackend {
         window: Arc<dyn anyrender::WindowHandle>,
         width: u32,
         height: u32,
+        composite_alpha_mode: anyrender::CompositeAlphaMode,
     ) -> VulkanBackend {
         let entry = unsafe { Entry::load().unwrap() };
 
@@ -100,6 +102,7 @@ impl VulkanBackend {
                 surface,
                 queue_family_index,
                 swapchain_size,
+                composite_alpha_mode,
                 None,
             );
 
@@ -161,6 +164,7 @@ impl VulkanBackend {
             in_flight_fence,
             cmd_pool,
             cmd_buf,
+            composite_alpha_mode,
         }
     }
 
@@ -180,6 +184,7 @@ impl VulkanBackend {
                 self.surface,
                 self.queue_family_index,
                 self.swapchain_size,
+                self.composite_alpha_mode,
                 Some(old_swapchain),
             );
         self.swapchain = swapchain;
@@ -468,6 +473,7 @@ fn create_swapchain(
     surface: SurfaceKHR,
     queue_family_index: u32,
     size: (u32, u32),
+    composite_alpha_mode: anyrender::CompositeAlphaMode,
     old_swapchain: Option<SwapchainKHR>,
 ) -> (
     SwapchainKHR,
@@ -524,6 +530,43 @@ fn create_swapchain(
 
     let image_count = surface_caps.min_image_count.max(2);
 
+    let supported = surface_caps.supported_composite_alpha;
+    let composite_alpha = match composite_alpha_mode {
+        anyrender::CompositeAlphaMode::Opaque
+            if supported.contains(CompositeAlphaFlagsKHR::OPAQUE) =>
+        {
+            CompositeAlphaFlagsKHR::OPAQUE
+        }
+        anyrender::CompositeAlphaMode::PreMultiplied
+            if supported.contains(CompositeAlphaFlagsKHR::PRE_MULTIPLIED) =>
+        {
+            CompositeAlphaFlagsKHR::PRE_MULTIPLIED
+        }
+        anyrender::CompositeAlphaMode::PostMultiplied
+            if supported.contains(CompositeAlphaFlagsKHR::POST_MULTIPLIED) =>
+        {
+            CompositeAlphaFlagsKHR::POST_MULTIPLIED
+        }
+        anyrender::CompositeAlphaMode::Inherit
+            if supported.contains(CompositeAlphaFlagsKHR::INHERIT) =>
+        {
+            CompositeAlphaFlagsKHR::INHERIT
+        }
+        _ => {
+            if supported.contains(CompositeAlphaFlagsKHR::OPAQUE) {
+                CompositeAlphaFlagsKHR::OPAQUE
+            } else if supported.contains(CompositeAlphaFlagsKHR::INHERIT) {
+                CompositeAlphaFlagsKHR::INHERIT
+            } else if supported.contains(CompositeAlphaFlagsKHR::PRE_MULTIPLIED) {
+                CompositeAlphaFlagsKHR::PRE_MULTIPLIED
+            } else if supported.contains(CompositeAlphaFlagsKHR::POST_MULTIPLIED) {
+                CompositeAlphaFlagsKHR::POST_MULTIPLIED
+            } else {
+                supported
+            }
+        }
+    };
+
     let create_info = SwapchainCreateInfoKHR::default()
         .surface(surface)
         .min_image_count(image_count)
@@ -540,7 +583,7 @@ fn create_swapchain(
         .image_sharing_mode(SharingMode::EXCLUSIVE)
         .queue_family_indices(std::slice::from_ref(&queue_family_index))
         .pre_transform(surface_caps.current_transform)
-        .composite_alpha(CompositeAlphaFlagsKHR::OPAQUE)
+        .composite_alpha(composite_alpha)
         .present_mode(present_mode)
         .clipped(true)
         .old_swapchain(old_swapchain.unwrap_or(SwapchainKHR::null()));

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -33,9 +33,19 @@ pub struct SkiaRendererOptions {
 
 impl Default for SkiaRendererOptions {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SkiaRendererOptions {
+    pub const fn new() -> Self {
         Self {
             base_color: Color::WHITE,
         }
+    }
+
+    pub const fn base_color(self, base_color: Color) -> Self {
+        Self { base_color, ..self }
     }
 }
 

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -150,13 +150,19 @@ impl WindowRenderer for SkiaWindowRenderer {
 ))]
 pub mod raster {
     #[cfg(feature = "pixels_window_renderer")]
+    pub use pixels_window_renderer::PixelsRendererOptions;
+    #[cfg(feature = "pixels_window_renderer")]
     pub use pixels_window_renderer::PixelsWindowRenderer;
+
     #[cfg(feature = "softbuffer_window_renderer")]
     pub use softbuffer_window_renderer::SoftbufferWindowRenderer;
 
     #[cfg(feature = "pixels_window_renderer")]
     pub type SkiaRasterWindowRenderer =
         PixelsWindowRenderer<crate::image_renderer::SkiaImageRenderer>;
+    #[cfg(feature = "pixels_window_renderer")]
+    pub type SkiaRasterRendererOptions = PixelsRendererOptions;
+
     #[cfg(all(
         feature = "softbuffer_window_renderer",
         not(feature = "pixels_window_renderer")

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -1,11 +1,12 @@
 use anyrender::{RenderContext, WindowRenderer};
 use debug_timer::debug_timer;
 use skia_safe::{Color, Surface, graphics};
+use std::any::Any;
 use std::sync::Arc;
 
 use crate::{SkiaScenePainter, scene::SkiaSceneCache};
 
-pub(crate) trait SkiaBackend {
+pub(crate) trait SkiaBackend: Any {
     fn set_size(&mut self, width: u32, height: u32);
 
     fn prepare(&mut self) -> Option<Surface>;
@@ -160,6 +161,43 @@ impl WindowRenderer for SkiaWindowRenderer {
 
     fn is_active(&self) -> bool {
         matches!(self.render_state, RenderState::Active(..))
+    }
+
+    fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
+        let RenderState::Active(state) = &self.render_state else {
+            return None;
+        };
+        let any_backend = &*state.backend as &dyn Any;
+
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        let is_gl = any_backend.is::<crate::opengl::OpenGLBackend>();
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        let is_gl = false;
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        let is_metal = any_backend.is::<crate::metal::MetalBackend>();
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        let is_metal = false;
+
+        if is_gl || is_metal {
+            return match self.options.composite_alpha_mode {
+                anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto => {
+                    Some(anyrender::CurrentCompositeAlphaMode::Opaque)
+                }
+                anyrender::CompositeAlphaMode::Transparent => {
+                    Some(anyrender::CurrentCompositeAlphaMode::PreMultiplied)
+                }
+            };
+        };
+        #[cfg(feature = "vulkan")]
+        {
+            any_backend
+                .downcast_ref::<crate::vulkan::VulkanBackend>()
+                .map(|b| b.current_alpha_mode())
+        }
+        #[cfg(not(feature = "vulkan"))]
+        {
+            None
+        }
     }
 
     fn set_size(&mut self, width: u32, height: u32) {

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -163,43 +163,6 @@ impl WindowRenderer for SkiaWindowRenderer {
         matches!(self.render_state, RenderState::Active(..))
     }
 
-    fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
-        let RenderState::Active(state) = &self.render_state else {
-            return None;
-        };
-        let any_backend = &*state.backend as &dyn Any;
-
-        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-        let is_gl = any_backend.is::<crate::opengl::OpenGLBackend>();
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
-        let is_gl = false;
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
-        let is_metal = any_backend.is::<crate::metal::MetalBackend>();
-        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-        let is_metal = false;
-
-        if is_gl || is_metal {
-            return match self.options.composite_alpha_mode {
-                anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto => {
-                    Some(anyrender::CurrentCompositeAlphaMode::Opaque)
-                }
-                anyrender::CompositeAlphaMode::Transparent => {
-                    Some(anyrender::CurrentCompositeAlphaMode::PreMultiplied)
-                }
-            };
-        };
-        #[cfg(feature = "vulkan")]
-        {
-            any_backend
-                .downcast_ref::<crate::vulkan::VulkanBackend>()
-                .map(|b| b.current_alpha_mode())
-        }
-        #[cfg(not(feature = "vulkan"))]
-        {
-            None
-        }
-    }
-
     fn set_size(&mut self, width: u32, height: u32) {
         if let RenderState::Active(state) = &mut self.render_state {
             state.backend.set_size(width, height);

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -23,9 +23,11 @@ struct ActiveRenderState {
     scene_cache: SkiaSceneCache,
 }
 
+/// Options for configuring the Skia renderer.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct SkiaRendererOptions {
+    /// Background color used to clear the canvas.
     pub base_color: Color,
 }
 

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -23,8 +23,23 @@ struct ActiveRenderState {
     scene_cache: SkiaSceneCache,
 }
 
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SkiaRendererOptions {
+    pub base_color: Color,
+}
+
+impl Default for SkiaRendererOptions {
+    fn default() -> Self {
+        Self {
+            base_color: Color::WHITE,
+        }
+    }
+}
+
 pub struct SkiaWindowRenderer {
     render_state: RenderState,
+    options: SkiaRendererOptions,
 }
 
 impl Default for SkiaWindowRenderer {
@@ -37,6 +52,13 @@ impl SkiaWindowRenderer {
     pub fn new() -> Self {
         Self {
             render_state: RenderState::Suspended,
+            options: SkiaRendererOptions::default(),
+        }
+    }
+    pub fn with_options(options: SkiaRendererOptions) -> Self {
+        Self {
+            render_state: RenderState::Suspended,
+            options,
         }
     }
 }
@@ -104,7 +126,7 @@ impl WindowRenderer for SkiaWindowRenderer {
         };
 
         surface.canvas().restore_to_count(1);
-        surface.canvas().clear(Color::WHITE);
+        surface.canvas().clear(self.options.base_color);
 
         draw_fn(&mut SkiaScenePainter {
             inner: surface.canvas(),

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -63,10 +63,9 @@ impl SkiaRendererOptions {
     }
 }
 
-impl TryFrom<anyrender::RendererConfig> for SkiaRendererOptions {
-    type Error = anyrender::ConfigError;
+impl From<anyrender::RendererConfig> for SkiaRendererOptions {
 
-    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+    fn from(config: anyrender::RendererConfig) -> Self {
         let mut options = Self::default();
         if let Some(color) = config.base_color {
             let rgba8 = color.to_rgba8();
@@ -75,7 +74,7 @@ impl TryFrom<anyrender::RendererConfig> for SkiaRendererOptions {
         if let Some(mode) = config.composite_alpha_mode {
             options.composite_alpha_mode = mode;
         }
-        Ok(options)
+            options
     }
 }
 
@@ -98,13 +97,11 @@ impl SkiaWindowRenderer {
         }
     }
     pub fn with_options(
-        options: impl TryInto<SkiaRendererOptions, Error = impl std::error::Error>,
+        options: impl Into<SkiaRendererOptions>,
     ) -> Self {
         Self {
             render_state: RenderState::Suspended,
-            options: options
-                .try_into()
-                .expect("Invalid Skia renderer configuration"),
+            options: options.into()
         }
     }
 }

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -29,6 +29,8 @@ struct ActiveRenderState {
 pub struct SkiaRendererOptions {
     /// Background color used to clear the canvas.
     pub base_color: Color,
+    /// Alpha mode used when compositing the window surface.
+    pub composite_alpha_mode: anyrender::CompositeAlphaMode,
 }
 
 impl Default for SkiaRendererOptions {
@@ -41,11 +43,22 @@ impl SkiaRendererOptions {
     pub const fn new() -> Self {
         Self {
             base_color: Color::WHITE,
+            composite_alpha_mode: anyrender::CompositeAlphaMode::Auto,
         }
     }
 
     pub const fn base_color(self, base_color: Color) -> Self {
         Self { base_color, ..self }
+    }
+
+    pub const fn composite_alpha_mode(
+        self,
+        composite_alpha_mode: anyrender::CompositeAlphaMode,
+    ) -> Self {
+        Self {
+            composite_alpha_mode,
+            ..self
+        }
     }
 }
 
@@ -53,15 +66,13 @@ impl TryFrom<anyrender::RendererConfig> for SkiaRendererOptions {
     type Error = anyrender::ConfigError;
 
     fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
-        if config.composite_alpha_mode.is_some() {
-            return Err(anyrender::ConfigError::UnsupportedField(
-                "composite_alpha_mode",
-            ));
-        }
         let mut options = Self::default();
         if let Some(color) = config.base_color {
             let rgba8 = color.to_rgba8();
             options.base_color = skia_safe::Color::from_argb(rgba8.a, rgba8.r, rgba8.g, rgba8.b);
+        }
+        if let Some(mode) = config.composite_alpha_mode {
+            options.composite_alpha_mode = mode;
         }
         Ok(options)
     }
@@ -118,9 +129,19 @@ impl WindowRenderer for SkiaWindowRenderer {
         graphics::set_resource_cache_total_bytes_limit(10485760);
 
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        let backend = crate::metal::MetalBackend::new(window, width, height);
+        let backend = crate::metal::MetalBackend::new(
+            window,
+            width,
+            height,
+            self.options.composite_alpha_mode,
+        );
         #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-        let backend = crate::opengl::OpenGLBackend::new(window, width, height);
+        let backend = crate::opengl::OpenGLBackend::new(
+            window,
+            width,
+            height,
+            self.options.composite_alpha_mode,
+        );
 
         self.render_state = RenderState::Active(Box::new(ActiveRenderState {
             backend: Box::new(backend),

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -64,7 +64,6 @@ impl SkiaRendererOptions {
 }
 
 impl From<anyrender::RendererConfig> for SkiaRendererOptions {
-
     fn from(config: anyrender::RendererConfig) -> Self {
         let mut options = Self::default();
         if let Some(color) = config.base_color {
@@ -74,7 +73,7 @@ impl From<anyrender::RendererConfig> for SkiaRendererOptions {
         if let Some(mode) = config.composite_alpha_mode {
             options.composite_alpha_mode = mode;
         }
-            options
+        options
     }
 }
 
@@ -96,12 +95,10 @@ impl SkiaWindowRenderer {
             options: SkiaRendererOptions::default(),
         }
     }
-    pub fn with_options(
-        options: impl Into<SkiaRendererOptions>,
-    ) -> Self {
+    pub fn with_options(options: impl Into<SkiaRendererOptions>) -> Self {
         Self {
             render_state: RenderState::Suspended,
-            options: options.into()
+            options: options.into(),
         }
     }
 }

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -49,6 +49,24 @@ impl SkiaRendererOptions {
     }
 }
 
+impl TryFrom<anyrender::RendererConfig> for SkiaRendererOptions {
+    type Error = anyrender::ConfigError;
+
+    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+        if config.composite_alpha_mode.is_some() {
+            return Err(anyrender::ConfigError::UnsupportedField(
+                "composite_alpha_mode",
+            ));
+        }
+        let mut options = Self::default();
+        if let Some(color) = config.base_color {
+            let rgba8 = color.to_rgba8();
+            options.base_color = skia_safe::Color::from_argb(rgba8.a, rgba8.r, rgba8.g, rgba8.b);
+        }
+        Ok(options)
+    }
+}
+
 pub struct SkiaWindowRenderer {
     render_state: RenderState,
     options: SkiaRendererOptions,
@@ -67,10 +85,14 @@ impl SkiaWindowRenderer {
             options: SkiaRendererOptions::default(),
         }
     }
-    pub fn with_options(options: SkiaRendererOptions) -> Self {
+    pub fn with_options(
+        options: impl TryInto<SkiaRendererOptions, Error = impl std::error::Error>,
+    ) -> Self {
         Self {
             render_state: RenderState::Suspended,
-            options,
+            options: options
+                .try_into()
+                .expect("Invalid Skia renderer configuration"),
         }
     }
 }

--- a/crates/anyrender_skia/src/window_renderer.rs
+++ b/crates/anyrender_skia/src/window_renderer.rs
@@ -210,7 +210,7 @@ pub mod raster {
     pub use pixels_window_renderer::PixelsWindowRenderer;
 
     #[cfg(feature = "softbuffer_window_renderer")]
-    pub use softbuffer_window_renderer::SoftbufferWindowRenderer;
+    pub use softbuffer_window_renderer::{SoftbufferRendererOptions, SoftbufferWindowRenderer};
 
     #[cfg(feature = "pixels_window_renderer")]
     pub type SkiaRasterWindowRenderer =
@@ -224,4 +224,9 @@ pub mod raster {
     ))]
     pub type SkiaRasterWindowRenderer =
         SoftbufferWindowRenderer<crate::image_renderer::SkiaImageRenderer>;
+    #[cfg(all(
+        feature = "softbuffer_window_renderer",
+        not(feature = "pixels_window_renderer")
+    ))]
+    pub type SkiaRasterRendererOptions = SoftbufferRendererOptions;
 }

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -299,9 +299,9 @@ impl WindowRenderer for VelloWindowRenderer {
             let adapter = &device_handle.adapter;
             let caps = surface.get_capabilities(adapter);
             let mut alpha_modes = caps.alpha_modes;
-            let found = alpha_modes.iter().find(|m| **m == composite_alpha_mode);
+            let found = alpha_modes.contains(&composite_alpha_mode);
 
-            if found.is_none() {
+            if found {
                 alpha_modes.sort_unstable_by(
                     |first: &CompositeAlphaMode, second: &CompositeAlphaMode| {
                         let first_num = match *first {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -119,15 +119,14 @@ impl VelloRendererOptions {
     }
 }
 
-impl TryFrom<anyrender::RendererConfig> for VelloRendererOptions {
-    type Error = anyrender::ConfigError;
+impl From<anyrender::RendererConfig> for VelloRendererOptions {
 
-    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
-        Ok(Self {
+    fn from(config: anyrender::RendererConfig) -> Self {
+        Self {
             base_color: config.base_color.unwrap_or(Color::WHITE),
             composite_alpha_mode: config.composite_alpha_mode.unwrap_or_default(),
             ..Default::default()
-        })
+        }
     }
 }
 
@@ -152,11 +151,9 @@ impl VelloWindowRenderer {
     }
 
     pub fn with_options(
-        config: impl TryInto<VelloRendererOptions, Error = impl std::error::Error>,
+        config: impl Into<VelloRendererOptions>,
     ) -> Self {
-        let config = config
-            .try_into()
-            .expect("Invalid Vello renderer configuration");
+        let config = config.into();
         Self {
             render_state: RenderState::Suspended,
             wgpu_context: build_wgpu_context(&config),

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -204,6 +204,7 @@ impl WindowRenderer for VelloWindowRenderer {
         let instance = self.wgpu_context.instance.clone();
         let extra_features = self.wgpu_context.extra_features();
         let override_limits = self.wgpu_context.override_limits();
+        let composite_alpha_mode = self.config.composite_alpha_mode;
         let existing_device_handle = self
             .wgpu_context
             .find_compatible_device_handle(Some(&surface));
@@ -230,7 +231,7 @@ impl WindowRenderer for VelloWindowRenderer {
                     height,
                     present_mode: PresentMode::AutoVsync,
                     desired_maximum_frame_latency: 2,
-                    alpha_mode: self.config.composite_alpha_mode,
+                    alpha_mode: composite_alpha_mode,
                     view_formats: vec![],
                 },
                 Some(TextureConfiguration {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -325,10 +325,7 @@ impl WindowRenderer for VelloWindowRenderer {
             let texture_config = Some(TextureConfiguration {
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba8Unorm,
-                alpha_conversion: (composite_alpha_mode != CompositeAlphaMode::PostMultiplied
-                    || composite_alpha_mode != CompositeAlphaMode::Opaque
-                    || composite_alpha_mode != CompositeAlphaMode::Inherit
-                    || composite_alpha_mode != CompositeAlphaMode::Auto)
+                alpha_conversion: (composite_alpha_mode == CompositeAlphaMode::PreMultiplied)
                     .then_some(AlphaConversion::Premultiply),
             });
             // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -333,7 +333,9 @@ impl WindowRenderer for VelloWindowRenderer {
             let texture_config = Some(TextureConfiguration {
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba8Unorm,
-                alpha_conversion: Some(AlphaConversion::Premultiply),
+                alpha_conversion: (composite_alpha_mode == CompositeAlphaMode::PostMultiplied
+                    || composite_alpha_mode == CompositeAlphaMode::PreMultiplied)
+                    .then_some(AlphaConversion::Premultiply),
             });
 
             let render_surface = SurfaceRenderer::new(

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -412,37 +412,6 @@ impl WindowRenderer for VelloWindowRenderer {
         };
     }
 
-    // fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
-    //     let RenderState::Active(state) = &self.render_state else {
-    //         return None;
-    //     };
-    //     #[cfg(not(target_vendor = "apple"))]
-    //     {
-    //         match state.render_surface.surface.get_configuration()?.alpha_mode {
-    //             CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
-    //             CompositeAlphaMode::PostMultiplied => {
-    //                 Some(CurrentCompositeAlphaMode::PostMultiplied)
-    //             }
-    //             CompositeAlphaMode::Auto
-    //             | CompositeAlphaMode::Opaque
-    //             | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
-    //         }
-    //     }
-    //     // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
-    //     #[cfg(target_vendor = "apple")]
-    //     {
-    //         match state.render_surface.surface.get_configuration()?.alpha_mode {
-    //             CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
-    //             CompositeAlphaMode::PostMultiplied => {
-    //                 Some(CurrentCompositeAlphaMode::PreMultiplied)
-    //             }
-    //             CompositeAlphaMode::Auto
-    //             | CompositeAlphaMode::Opaque
-    //             | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
-    //         }
-    //     }
-    // }
-
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {
         let RenderState::Active(state) = &mut self.render_state else {
             return;

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -115,6 +115,31 @@ impl VelloRendererOptions {
     }
 }
 
+impl TryFrom<anyrender::RendererConfig> for VelloRendererOptions {
+    type Error = anyrender::ConfigError;
+
+    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+        let mut options = Self::default();
+        if let Some(color) = config.base_color {
+            options.base_color = color;
+        }
+        if let Some(mode) = config.composite_alpha_mode {
+            options.composite_alpha_mode = match mode {
+                anyrender::CompositeAlphaMode::Auto => wgpu::CompositeAlphaMode::Auto,
+                anyrender::CompositeAlphaMode::Opaque => wgpu::CompositeAlphaMode::Opaque,
+                anyrender::CompositeAlphaMode::PreMultiplied => {
+                    wgpu::CompositeAlphaMode::PreMultiplied
+                }
+                anyrender::CompositeAlphaMode::PostMultiplied => {
+                    wgpu::CompositeAlphaMode::PostMultiplied
+                }
+                anyrender::CompositeAlphaMode::Inherit => wgpu::CompositeAlphaMode::Inherit,
+            };
+        }
+        Ok(options)
+    }
+}
+
 pub struct VelloWindowRenderer {
     // The fields MUST be in this order, so that the surface is dropped before the window
     // Window is cached even when suspended so that it can be reused when the app is resumed after being suspended
@@ -135,7 +160,12 @@ impl VelloWindowRenderer {
         Self::with_options(VelloRendererOptions::default())
     }
 
-    pub fn with_options(config: VelloRendererOptions) -> Self {
+    pub fn with_options(
+        config: impl TryInto<VelloRendererOptions, Error = impl std::error::Error>,
+    ) -> Self {
+        let config = config
+            .try_into()
+            .expect("Invalid Vello renderer configuration");
         Self {
             render_state: RenderState::Suspended,
             wgpu_context: build_wgpu_context(&config),

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -293,9 +293,8 @@ impl WindowRenderer for VelloWindowRenderer {
             let adapter = &device_handle.adapter;
             let caps = surface.get_capabilities(adapter);
             let mut alpha_modes = caps.alpha_modes;
-            let found = alpha_modes.contains(&composite_alpha_mode);
 
-            if found {
+            if !alpha_modes.contains(&composite_alpha_mode) {
                 alpha_modes.sort_unstable_by(
                     |first: &CompositeAlphaMode, second: &CompositeAlphaMode| {
                         let first_num = match *first {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -16,7 +16,8 @@ use wgpu::{
     CompositeAlphaMode, Features, Limits, PresentMode, Texture, TextureFormat, TextureUsages,
 };
 use wgpu_context::{
-    DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, TextureConfiguration, WGPUContext,
+    AlphaConversion, DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration,
+    TextureConfiguration, WGPUContext,
 };
 
 use crate::{DEFAULT_THREADS, VelloScenePainter};
@@ -341,6 +342,14 @@ impl WindowRenderer for VelloWindowRenderer {
                 },
                 Some(TextureConfiguration {
                     usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
+                    // Vello's compute pipeline outputs to an Rgba8Unorm storage texture.
+                    format: TextureFormat::Rgba8Unorm,
+                    // Vello Classic's `fine` shader writes straight (non-premultiplied)
+                    // alpha. A `PreMultiplied` surface expects premultiplied colour, so
+                    // premultiply on the way out; other modes want straight alpha
+                    // (PostMultiplied) or ignore it (Opaque), so no conversion is needed.
+                    alpha_conversion: (composite_alpha_mode == CompositeAlphaMode::PreMultiplied)
+                        .then_some(AlphaConversion::Premultiply),
                 }),
                 device_handle,
             )

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -328,6 +328,23 @@ impl WindowRenderer for VelloWindowRenderer {
                     .expect("Surface didn't report any alpha modes");
             }
 
+            #[cfg(not(target_vendor = "apple"))]
+            let texture_config =
+                (composite_alpha_mode == CompositeAlphaMode::PreMultiplied).then(|| {
+                    TextureConfiguration {
+                        usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
+                        format: TextureFormat::Rgba8Unorm,
+                        alpha_conversion: Some(AlphaConversion::Premultiply),
+                    }
+                });
+            // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
+            #[cfg(target_vendor = "apple")]
+            let texture_config = Some(TextureConfiguration {
+                usage: TextureUsages::STORAGE_BINDING,
+                format: TextureFormat::Rgba8Unorm,
+                alpha_conversion: Some(AlphaConversion::Premultiply),
+            });
+
             let render_surface = SurfaceRenderer::new(
                 surface,
                 SurfaceRendererConfiguration {
@@ -340,17 +357,7 @@ impl WindowRenderer for VelloWindowRenderer {
                     alpha_mode: composite_alpha_mode,
                     view_formats: vec![],
                 },
-                Some(TextureConfiguration {
-                    usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
-                    // Vello's compute pipeline outputs to an Rgba8Unorm storage texture.
-                    format: TextureFormat::Rgba8Unorm,
-                    // Vello Classic's `fine` shader writes straight (non-premultiplied)
-                    // alpha. A `PreMultiplied` surface expects premultiplied colour, so
-                    // premultiply on the way out; other modes want straight alpha
-                    // (PostMultiplied) or ignore it (Opaque), so no conversion is needed.
-                    alpha_conversion: (composite_alpha_mode == CompositeAlphaMode::PreMultiplied)
-                        .then_some(AlphaConversion::Premultiply),
-                }),
+                texture_config,
                 device_handle,
             )
             .expect("Error creating SurfaceRenderer");

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -62,7 +62,7 @@ pub struct VelloRendererOptions {
     pub base_color: Color,
     pub antialiasing_method: AaConfig,
     /// Alpha mode used when compositing the window surface.
-    pub composite_alpha_mode: CompositeAlphaMode,
+    pub composite_alpha_mode: anyrender::CompositeAlphaMode,
 }
 
 impl Default for VelloRendererOptions {
@@ -78,7 +78,7 @@ impl VelloRendererOptions {
             limits: None,
             base_color: Color::WHITE,
             antialiasing_method: AaConfig::Msaa16,
-            composite_alpha_mode: CompositeAlphaMode::Auto,
+            composite_alpha_mode: anyrender::CompositeAlphaMode::Auto,
         }
     }
 
@@ -107,7 +107,10 @@ impl VelloRendererOptions {
         }
     }
 
-    pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
+    pub const fn composite_alpha_mode(
+        self,
+        composite_alpha_mode: anyrender::types::CompositeAlphaMode,
+    ) -> Self {
         Self {
             composite_alpha_mode,
             ..self
@@ -119,24 +122,11 @@ impl TryFrom<anyrender::RendererConfig> for VelloRendererOptions {
     type Error = anyrender::ConfigError;
 
     fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
-        let mut options = Self::default();
-        if let Some(color) = config.base_color {
-            options.base_color = color;
-        }
-        if let Some(mode) = config.composite_alpha_mode {
-            options.composite_alpha_mode = match mode {
-                anyrender::CompositeAlphaMode::Auto => wgpu::CompositeAlphaMode::Auto,
-                anyrender::CompositeAlphaMode::Opaque => wgpu::CompositeAlphaMode::Opaque,
-                anyrender::CompositeAlphaMode::PreMultiplied => {
-                    wgpu::CompositeAlphaMode::PreMultiplied
-                }
-                anyrender::CompositeAlphaMode::PostMultiplied => {
-                    wgpu::CompositeAlphaMode::PostMultiplied
-                }
-                anyrender::CompositeAlphaMode::Inherit => wgpu::CompositeAlphaMode::Inherit,
-            };
-        }
-        Ok(options)
+        Ok(Self {
+            base_color: config.base_color.unwrap_or(Color::WHITE),
+            composite_alpha_mode: config.composite_alpha_mode.unwrap_or_default(),
+            ..Default::default()
+        })
     }
 }
 
@@ -272,7 +262,22 @@ impl WindowRenderer for VelloWindowRenderer {
         let instance = self.wgpu_context.instance.clone();
         let extra_features = self.wgpu_context.extra_features();
         let override_limits = self.wgpu_context.override_limits();
-        let composite_alpha_mode = self.config.composite_alpha_mode;
+        let composite_alpha_mode = match self.config.composite_alpha_mode {
+            anyrender::CompositeAlphaMode::Auto => CompositeAlphaMode::Auto,
+            anyrender::CompositeAlphaMode::Opaque => CompositeAlphaMode::Opaque,
+            anyrender::CompositeAlphaMode::Transparent => {
+                #[cfg(target_vendor = "apple")]
+                {
+                    // wgpu is lying in apple's case it uses PreMultiplied in reality
+                    // (do not modify shaders for PostMultiplied)
+                    CompositeAlphaMode::PostMultiplied
+                }
+                #[cfg(not(target_vendor = "apple"))]
+                {
+                    CompositeAlphaMode::PreMultiplied
+                }
+            }
+        };
         let existing_device_handle = self
             .wgpu_context
             .find_compatible_device_handle(Some(&surface));

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -329,18 +329,16 @@ impl WindowRenderer for VelloWindowRenderer {
             }
 
             #[cfg(not(target_vendor = "apple"))]
-            let texture_config =
-                (composite_alpha_mode == CompositeAlphaMode::PreMultiplied).then(|| {
-                    TextureConfiguration {
-                        usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
-                        format: TextureFormat::Rgba8Unorm,
-                        alpha_conversion: Some(AlphaConversion::Premultiply),
-                    }
-                });
+            let texture_config = Some(TextureConfiguration {
+                usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
+                format: TextureFormat::Rgba8Unorm,
+                alpha_conversion: (composite_alpha_mode == CompositeAlphaMode::PreMultiplied)
+                    .then_some(AlphaConversion::Premultiply),
+            });
             // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
             #[cfg(target_vendor = "apple")]
             let texture_config = Some(TextureConfiguration {
-                usage: TextureUsages::STORAGE_BINDING,
+                usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba8Unorm,
                 alpha_conversion: Some(AlphaConversion::Premultiply),
             });

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -67,12 +67,50 @@ pub struct VelloRendererOptions {
 
 impl Default for VelloRendererOptions {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VelloRendererOptions {
+    pub const fn new() -> Self {
         Self {
             features: None,
             limits: None,
             base_color: Color::WHITE,
             antialiasing_method: AaConfig::Msaa16,
             composite_alpha_mode: CompositeAlphaMode::Auto,
+        }
+    }
+
+    pub const fn features(self, features: Features) -> Self {
+        Self {
+            features: Some(features),
+            ..self
+        }
+    }
+
+    pub const fn limits(self, limits: Limits) -> Self {
+        Self {
+            limits: Some(limits),
+            ..self
+        }
+    }
+
+    pub const fn base_color(self, base_color: Color) -> Self {
+        Self { base_color, ..self }
+    }
+
+    pub const fn antialiasing_method(self, antialiasing_method: AaConfig) -> Self {
+        Self {
+            antialiasing_method,
+            ..self
+        }
+    }
+
+    pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
+        Self {
+            composite_alpha_mode,
+            ..self
         }
     }
 }

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -120,7 +120,6 @@ impl VelloRendererOptions {
 }
 
 impl From<anyrender::RendererConfig> for VelloRendererOptions {
-
     fn from(config: anyrender::RendererConfig) -> Self {
         Self {
             base_color: config.base_color.unwrap_or(Color::WHITE),
@@ -150,9 +149,7 @@ impl VelloWindowRenderer {
         Self::with_options(VelloRendererOptions::default())
     }
 
-    pub fn with_options(
-        config: impl Into<VelloRendererOptions>,
-    ) -> Self {
+    pub fn with_options(config: impl Into<VelloRendererOptions>) -> Self {
         let config = config.into();
         Self {
             render_state: RenderState::Suspended,

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -53,6 +53,7 @@ enum RenderState {
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct VelloRendererOptions {
     pub features: Option<Features>,
     pub limits: Option<Limits>,

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -325,7 +325,8 @@ impl WindowRenderer for VelloWindowRenderer {
             let texture_config = Some(TextureConfiguration {
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba8Unorm,
-                alpha_conversion: (composite_alpha_mode != CompositeAlphaMode::PostMultiplied)
+                alpha_conversion: (composite_alpha_mode != CompositeAlphaMode::PostMultiplied
+                    || composite_alpha_mode != CompositeAlphaMode::Opaque)
                     .then_some(AlphaConversion::Premultiply),
             });
             // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -11,7 +11,9 @@ use vello::{
     AaConfig, AaSupport, RenderParams, Renderer as VelloRenderer, RendererOptions,
     Scene as VelloScene,
 };
-use wgpu::{Features, Limits, PresentMode, Texture, TextureFormat, TextureUsages};
+use wgpu::{
+    CompositeAlphaMode, Features, Limits, PresentMode, Texture, TextureFormat, TextureUsages,
+};
 use wgpu_context::{
     DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, TextureConfiguration, WGPUContext,
 };
@@ -59,6 +61,7 @@ pub struct VelloRendererOptions {
     pub limits: Option<Limits>,
     pub base_color: Color,
     pub antialiasing_method: AaConfig,
+    pub composite_alpha_mode: CompositeAlphaMode,
 }
 
 impl Default for VelloRendererOptions {
@@ -68,6 +71,7 @@ impl Default for VelloRendererOptions {
             limits: None,
             base_color: Color::WHITE,
             antialiasing_method: AaConfig::Msaa16,
+            composite_alpha_mode: CompositeAlphaMode::Auto,
         }
     }
 }
@@ -225,7 +229,7 @@ impl WindowRenderer for VelloWindowRenderer {
                     height,
                     present_mode: PresentMode::AutoVsync,
                     desired_maximum_frame_latency: 2,
-                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    alpha_mode: self.config.composite_alpha_mode,
                     view_formats: vec![],
                 },
                 Some(TextureConfiguration {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -1,6 +1,5 @@
 use anyrender::{
-    CurrentCompositeAlphaMode, RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle,
-    WindowRenderer,
+    RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
 };
 use debug_timer::debug_timer;
 use futures_channel::oneshot;
@@ -413,36 +412,36 @@ impl WindowRenderer for VelloWindowRenderer {
         };
     }
 
-    fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
-        let RenderState::Active(state) = &self.render_state else {
-            return None;
-        };
-        #[cfg(not(target_vendor = "apple"))]
-        {
-            match state.render_surface.surface.get_configuration()?.alpha_mode {
-                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
-                CompositeAlphaMode::PostMultiplied => {
-                    Some(CurrentCompositeAlphaMode::PostMultiplied)
-                }
-                CompositeAlphaMode::Auto
-                | CompositeAlphaMode::Opaque
-                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
-            }
-        }
-        // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
-        #[cfg(target_vendor = "apple")]
-        {
-            match state.render_surface.surface.get_configuration()?.alpha_mode {
-                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
-                CompositeAlphaMode::PostMultiplied => {
-                    Some(CurrentCompositeAlphaMode::PreMultiplied)
-                }
-                CompositeAlphaMode::Auto
-                | CompositeAlphaMode::Opaque
-                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
-            }
-        }
-    }
+    // fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
+    //     let RenderState::Active(state) = &self.render_state else {
+    //         return None;
+    //     };
+    //     #[cfg(not(target_vendor = "apple"))]
+    //     {
+    //         match state.render_surface.surface.get_configuration()?.alpha_mode {
+    //             CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
+    //             CompositeAlphaMode::PostMultiplied => {
+    //                 Some(CurrentCompositeAlphaMode::PostMultiplied)
+    //             }
+    //             CompositeAlphaMode::Auto
+    //             | CompositeAlphaMode::Opaque
+    //             | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
+    //         }
+    //     }
+    //     // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
+    //     #[cfg(target_vendor = "apple")]
+    //     {
+    //         match state.render_surface.surface.get_configuration()?.alpha_mode {
+    //             CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
+    //             CompositeAlphaMode::PostMultiplied => {
+    //                 Some(CurrentCompositeAlphaMode::PreMultiplied)
+    //             }
+    //             CompositeAlphaMode::Auto
+    //             | CompositeAlphaMode::Opaque
+    //             | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
+    //         }
+    //     }
+    // }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {
         let RenderState::Active(state) = &mut self.render_state else {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -61,6 +61,7 @@ pub struct VelloRendererOptions {
     pub limits: Option<Limits>,
     pub base_color: Color,
     pub antialiasing_method: AaConfig,
+    /// Alpha mode used when compositing the window surface.
     pub composite_alpha_mode: CompositeAlphaMode,
 }
 

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -326,7 +326,9 @@ impl WindowRenderer for VelloWindowRenderer {
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba8Unorm,
                 alpha_conversion: (composite_alpha_mode != CompositeAlphaMode::PostMultiplied
-                    || composite_alpha_mode != CompositeAlphaMode::Opaque)
+                    || composite_alpha_mode != CompositeAlphaMode::Opaque
+                    || composite_alpha_mode != CompositeAlphaMode::Inherit
+                    || composite_alpha_mode != CompositeAlphaMode::Auto)
                     .then_some(AlphaConversion::Premultiply),
             });
             // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -331,7 +331,7 @@ impl WindowRenderer for VelloWindowRenderer {
             let texture_config = Some(TextureConfiguration {
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 format: TextureFormat::Rgba8Unorm,
-                alpha_conversion: (composite_alpha_mode == CompositeAlphaMode::PreMultiplied)
+                alpha_conversion: (composite_alpha_mode != CompositeAlphaMode::PostMultiplied)
                     .then_some(AlphaConversion::Premultiply),
             });
             // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -1,5 +1,6 @@
 use anyrender::{
-    RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
+    CurrentCompositeAlphaMode, RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle,
+    WindowRenderer,
 };
 use debug_timer::debug_timer;
 use futures_channel::oneshot;
@@ -262,7 +263,7 @@ impl WindowRenderer for VelloWindowRenderer {
         let instance = self.wgpu_context.instance.clone();
         let extra_features = self.wgpu_context.extra_features();
         let override_limits = self.wgpu_context.override_limits();
-        let composite_alpha_mode = match self.config.composite_alpha_mode {
+        let mut composite_alpha_mode = match self.config.composite_alpha_mode {
             anyrender::CompositeAlphaMode::Auto => CompositeAlphaMode::Auto,
             anyrender::CompositeAlphaMode::Opaque => CompositeAlphaMode::Opaque,
             anyrender::CompositeAlphaMode::Transparent => {
@@ -294,6 +295,37 @@ impl WindowRenderer for VelloWindowRenderer {
                 .await
                 .expect("Error creating DeviceHandle"),
             };
+
+            let adapter = &device_handle.adapter;
+            let caps = surface.get_capabilities(adapter);
+            let mut alpha_modes = caps.alpha_modes;
+            let found = alpha_modes.iter().find(|m| **m == composite_alpha_mode);
+
+            if found.is_none() {
+                alpha_modes.sort_unstable_by(
+                    |first: &CompositeAlphaMode, second: &CompositeAlphaMode| {
+                        let first_num = match *first {
+                            CompositeAlphaMode::PreMultiplied => 0,
+                            CompositeAlphaMode::PostMultiplied => 1,
+                            CompositeAlphaMode::Opaque
+                            | CompositeAlphaMode::Inherit
+                            | CompositeAlphaMode::Auto => 2,
+                        };
+                        let second_num = match *second {
+                            CompositeAlphaMode::PreMultiplied => 0,
+                            CompositeAlphaMode::PostMultiplied => 1,
+                            CompositeAlphaMode::Opaque
+                            | CompositeAlphaMode::Inherit
+                            | CompositeAlphaMode::Auto => 2,
+                        };
+                        first_num.cmp(&second_num)
+                    },
+                );
+                composite_alpha_mode = alpha_modes
+                    .first()
+                    .copied()
+                    .expect("Surface didn't report any alpha modes");
+            }
 
             let render_surface = SurfaceRenderer::new(
                 surface,
@@ -365,6 +397,37 @@ impl WindowRenderer for VelloWindowRenderer {
         if let RenderState::Active(active) = &mut self.render_state {
             active.render_surface.resize(width, height);
         };
+    }
+
+    fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
+        let RenderState::Active(state) = &self.render_state else {
+            return None;
+        };
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            match state.render_surface.surface.get_configuration()?.alpha_mode {
+                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
+                CompositeAlphaMode::PostMultiplied => {
+                    Some(CurrentCompositeAlphaMode::PostMultiplied)
+                }
+                CompositeAlphaMode::Auto
+                | CompositeAlphaMode::Opaque
+                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
+            }
+        }
+        // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
+        #[cfg(target_vendor = "apple")]
+        {
+            match state.render_surface.surface.get_configuration()?.alpha_mode {
+                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
+                CompositeAlphaMode::PostMultiplied => {
+                    Some(CurrentCompositeAlphaMode::PreMultiplied)
+                }
+                CompositeAlphaMode::Auto
+                | CompositeAlphaMode::Opaque
+                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
+            }
+        }
     }
 
     fn render<F: FnOnce(&mut Self::ScenePainter<'_>)>(&mut self, draw_fn: F) {

--- a/crates/anyrender_vello_cpu/src/window_renderer.rs
+++ b/crates/anyrender_vello_cpu/src/window_renderer.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "softbuffer_window_renderer")]
-pub use softbuffer_window_renderer::SoftbufferWindowRenderer;
+pub use softbuffer_window_renderer::{SoftbufferRendererOptions, SoftbufferWindowRenderer};
 
 #[cfg(feature = "pixels_window_renderer")]
 pub use pixels_window_renderer::PixelsRendererOptions;
@@ -16,3 +16,8 @@ pub type VelloCpuRendererOptions = PixelsRendererOptions;
     not(feature = "pixels_window_renderer")
 ))]
 pub type VelloCpuWindowRenderer = SoftbufferWindowRenderer<crate::VelloCpuImageRenderer>;
+#[cfg(all(
+    feature = "softbuffer_window_renderer",
+    not(feature = "pixels_window_renderer")
+))]
+pub type VelloCpuRendererOptions = SoftbufferRendererOptions;

--- a/crates/anyrender_vello_cpu/src/window_renderer.rs
+++ b/crates/anyrender_vello_cpu/src/window_renderer.rs
@@ -2,10 +2,15 @@
 pub use softbuffer_window_renderer::SoftbufferWindowRenderer;
 
 #[cfg(feature = "pixels_window_renderer")]
+pub use pixels_window_renderer::PixelsRendererOptions;
+#[cfg(feature = "pixels_window_renderer")]
 pub use pixels_window_renderer::PixelsWindowRenderer;
 
 #[cfg(feature = "pixels_window_renderer")]
 pub type VelloCpuWindowRenderer = PixelsWindowRenderer<crate::VelloCpuImageRenderer>;
+#[cfg(feature = "pixels_window_renderer")]
+pub type VelloCpuRendererOptions = PixelsRendererOptions;
+
 #[cfg(all(
     feature = "softbuffer_window_renderer",
     not(feature = "pixels_window_renderer")

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -64,7 +64,7 @@ pub struct VelloHybridRendererOptions {
     pub render_settings: RenderSettings,
     pub base_color: Color,
     /// Alpha mode used when compositing the window surface.
-    pub composite_alpha_mode: CompositeAlphaMode,
+    pub composite_alpha_mode: anyrender::CompositeAlphaMode,
 }
 
 impl Default for VelloHybridRendererOptions {
@@ -74,7 +74,7 @@ impl Default for VelloHybridRendererOptions {
             limits: None,
             render_settings: RenderSettings::default(),
             base_color: Color::WHITE,
-            composite_alpha_mode: CompositeAlphaMode::Auto,
+            composite_alpha_mode: anyrender::CompositeAlphaMode::Auto,
         }
     }
 }
@@ -110,7 +110,10 @@ impl VelloHybridRendererOptions {
         Self { base_color, ..self }
     }
 
-    pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
+    pub const fn composite_alpha_mode(
+        self,
+        composite_alpha_mode: anyrender::CompositeAlphaMode,
+    ) -> Self {
         Self {
             composite_alpha_mode,
             ..self
@@ -122,24 +125,11 @@ impl TryFrom<anyrender::RendererConfig> for VelloHybridRendererOptions {
     type Error = anyrender::ConfigError;
 
     fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
-        let mut options = Self {
+        Ok(Self {
             base_color: config.base_color.unwrap_or(Color::WHITE),
+            composite_alpha_mode: config.composite_alpha_mode.unwrap_or_default(),
             ..Default::default()
-        };
-        if let Some(mode) = config.composite_alpha_mode {
-            options.composite_alpha_mode = match mode {
-                anyrender::CompositeAlphaMode::Auto => wgpu::CompositeAlphaMode::Auto,
-                anyrender::CompositeAlphaMode::Opaque => wgpu::CompositeAlphaMode::Opaque,
-                anyrender::CompositeAlphaMode::PreMultiplied => {
-                    wgpu::CompositeAlphaMode::PreMultiplied
-                }
-                anyrender::CompositeAlphaMode::PostMultiplied => {
-                    wgpu::CompositeAlphaMode::PostMultiplied
-                }
-                anyrender::CompositeAlphaMode::Inherit => wgpu::CompositeAlphaMode::Inherit,
-            };
-        }
-        Ok(options)
+        })
     }
 }
 
@@ -295,7 +285,22 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         let instance = self.wgpu_context.instance.clone();
         let extra_features = self.wgpu_context.extra_features();
         let override_limits = self.wgpu_context.override_limits();
-        let composite_alpha_mode = self.config.composite_alpha_mode;
+        let composite_alpha_mode = match self.config.composite_alpha_mode {
+            anyrender::CompositeAlphaMode::Auto => CompositeAlphaMode::Auto,
+            anyrender::CompositeAlphaMode::Opaque => CompositeAlphaMode::Opaque,
+            anyrender::CompositeAlphaMode::Transparent => {
+                #[cfg(target_vendor = "apple")]
+                {
+                    // wgpu is lying in apple's case it uses PreMultiplied in reality
+                    // (do not modify shaders for PostMultiplied)
+                    CompositeAlphaMode::PostMultiplied
+                }
+                #[cfg(not(target_vendor = "apple"))]
+                {
+                    CompositeAlphaMode::PreMultiplied
+                }
+            }
+        };
         let existing_device_handle = self
             .wgpu_context
             .find_compatible_device_handle(Some(&surface));

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -324,9 +324,9 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             let adapter = &device_handle.adapter;
             let caps = surface.get_capabilities(adapter);
             let mut alpha_modes = caps.alpha_modes;
-            let found = alpha_modes.iter().find(|m| **m == composite_alpha_mode);
+            let found = alpha_modes.contains(&composite_alpha_mode);
 
-            if found.is_none() {
+            if found {
                 alpha_modes.sort_unstable_by(
                     |first: &CompositeAlphaMode, second: &CompositeAlphaMode| {
                         let first_num = match *first {

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -61,6 +61,7 @@ pub struct VelloHybridRendererOptions {
     pub features: Option<Features>,
     pub limits: Option<Limits>,
     pub render_settings: RenderSettings,
+    /// Alpha mode used when compositing the window surface.
     pub composite_alpha_mode: CompositeAlphaMode,
 }
 

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -1,6 +1,5 @@
 use anyrender::{
-    CurrentCompositeAlphaMode, PaintScene, RegisterResourceErrorKind, RenderContext, ResourceId,
-    WindowHandle, WindowRenderer,
+    PaintScene, RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
 };
 use debug_timer::debug_timer;
 use futures_channel::oneshot;
@@ -441,37 +440,6 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             if let RenderState::Active(active) = &mut self.render_state {
                 active.render_surface.resize(width, height);
             };
-        }
-    }
-
-    fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
-        let RenderState::Active(state) = &self.render_state else {
-            return None;
-        };
-        #[cfg(not(target_vendor = "apple"))]
-        {
-            match state.render_surface.surface.get_configuration()?.alpha_mode {
-                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
-                CompositeAlphaMode::PostMultiplied => {
-                    Some(CurrentCompositeAlphaMode::PostMultiplied)
-                }
-                CompositeAlphaMode::Auto
-                | CompositeAlphaMode::Opaque
-                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
-            }
-        }
-        // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
-        #[cfg(target_vendor = "apple")]
-        {
-            match state.render_surface.surface.get_configuration()?.alpha_mode {
-                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
-                CompositeAlphaMode::PostMultiplied => {
-                    Some(CurrentCompositeAlphaMode::PreMultiplied)
-                }
-                CompositeAlphaMode::Auto
-                | CompositeAlphaMode::Opaque
-                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
-            }
         }
     }
 

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -100,6 +100,31 @@ impl VelloHybridRendererOptions {
     }
 }
 
+impl TryFrom<anyrender::RendererConfig> for VelloHybridRendererOptions {
+    type Error = anyrender::ConfigError;
+
+    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+        if config.base_color.is_some() {
+            return Err(anyrender::ConfigError::UnsupportedField("base_color"));
+        }
+        let mut options = Self::default();
+        if let Some(mode) = config.composite_alpha_mode {
+            options.composite_alpha_mode = match mode {
+                anyrender::CompositeAlphaMode::Auto => wgpu::CompositeAlphaMode::Auto,
+                anyrender::CompositeAlphaMode::Opaque => wgpu::CompositeAlphaMode::Opaque,
+                anyrender::CompositeAlphaMode::PreMultiplied => {
+                    wgpu::CompositeAlphaMode::PreMultiplied
+                }
+                anyrender::CompositeAlphaMode::PostMultiplied => {
+                    wgpu::CompositeAlphaMode::PostMultiplied
+                }
+                anyrender::CompositeAlphaMode::Inherit => wgpu::CompositeAlphaMode::Inherit,
+            };
+        }
+        Ok(options)
+    }
+}
+
 pub struct VelloHybridWindowRenderer {
     // The fields MUST be in this order, so that the surface is dropped before the window
     // Window is cached even when suspended so that it can be reused when the app is resumed after being suspended
@@ -117,7 +142,12 @@ impl VelloHybridWindowRenderer {
         Self::with_options(VelloHybridRendererOptions::default())
     }
 
-    pub fn with_options(config: VelloHybridRendererOptions) -> Self {
+    pub fn with_options(
+        config: impl TryInto<VelloHybridRendererOptions, Error = impl std::error::Error>,
+    ) -> Self {
+        let config = config
+            .try_into()
+            .expect("Invalid Vello Hybrid renderer configuration");
         let render_settings = config.render_settings;
         let wgpu_context = build_wgpu_context(&config);
         Self {

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -124,15 +124,13 @@ impl VelloHybridRendererOptions {
     }
 }
 
-impl TryFrom<anyrender::RendererConfig> for VelloHybridRendererOptions {
-    type Error = anyrender::ConfigError;
-
-    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<anyrender::RendererConfig> for VelloHybridRendererOptions {
+    fn from(config: anyrender::RendererConfig) -> Self {
+        Self {
             base_color: config.base_color.unwrap_or(Color::WHITE),
             composite_alpha_mode: config.composite_alpha_mode.unwrap_or_default(),
             ..Default::default()
-        })
+        }
     }
 }
 
@@ -154,11 +152,9 @@ impl VelloHybridWindowRenderer {
     }
 
     pub fn with_options(
-        config: impl TryInto<VelloHybridRendererOptions, Error = impl std::error::Error>,
+        config: impl Into<VelloHybridRendererOptions>,
     ) -> Self {
-        let config = config
-            .try_into()
-            .expect("Invalid Vello Hybrid renderer configuration");
+        let config = config.into();
         let render_settings = config.render_settings;
         let wgpu_context = build_wgpu_context(&config);
         Self {

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -15,9 +15,12 @@ use vello_hybrid::{
 };
 use wgpu::{
     CommandEncoderDescriptor, CompositeAlphaMode, Features, Limits, PresentMode, Texture,
-    TextureFormat, TextureView, TextureViewDescriptor,
+    TextureFormat, TextureUsages, TextureView, TextureViewDescriptor,
 };
-use wgpu_context::{DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, WGPUContext};
+use wgpu_context::{
+    AlphaConversion, DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration,
+    TextureConfiguration, WGPUContext,
+};
 
 use crate::{VelloHybridScenePainter, scene::ImageManager};
 
@@ -350,6 +353,19 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                     .expect("Surface didn't report any alpha modes");
             }
 
+            // Vello Hybrid emits premultiplied alpha and renders directly into
+            // its target. That matches a `PreMultiplied` surface (and Opaque
+            // ignores alpha), so those render straight to the surface. Only
+            // `PostMultiplied` (straight alpha) needs conversion, which routes
+            // through an intermediate texture (using the renderer's target
+            // format) that is un-premultiplied while blitting to the surface.
+            let intermediate_texture = (composite_alpha_mode == CompositeAlphaMode::PostMultiplied)
+                .then(|| TextureConfiguration {
+                    usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                    format: DEFAULT_TEXTURE_FORMAT,
+                    alpha_conversion: Some(AlphaConversion::Unpremultiply),
+                });
+
             let render_surface = SurfaceRenderer::new(
                 surface,
                 SurfaceRendererConfiguration {
@@ -362,7 +378,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                     alpha_mode: composite_alpha_mode,
                     view_formats: vec![],
                 },
-                None,
+                intermediate_texture,
                 device_handle,
             )
             .expect("Error creating SurfaceRenderer");

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -12,8 +12,8 @@ use vello_hybrid::{
     Scene as VelloHybridScene, TextureBindings,
 };
 use wgpu::{
-    CommandEncoderDescriptor, Features, Limits, PresentMode, Texture, TextureFormat, TextureView,
-    TextureViewDescriptor,
+    CommandEncoderDescriptor, CompositeAlphaMode, Features, Limits, PresentMode, Texture,
+    TextureFormat, TextureView, TextureViewDescriptor,
 };
 use wgpu_context::{DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, WGPUContext};
 
@@ -61,6 +61,7 @@ pub struct VelloHybridRendererOptions {
     pub features: Option<Features>,
     pub limits: Option<Limits>,
     pub render_settings: RenderSettings,
+    pub composite_alpha_mode: CompositeAlphaMode,
 }
 
 pub struct VelloHybridWindowRenderer {
@@ -236,7 +237,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                     height,
                     present_mode: PresentMode::AutoVsync,
                     desired_maximum_frame_latency: 2,
-                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    alpha_mode: self.config.composite_alpha_mode,
                     view_formats: vec![],
                 },
                 None,

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -1,8 +1,9 @@
 use anyrender::{
-    RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
+    PaintScene, RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
 };
 use debug_timer::debug_timer;
 use futures_channel::oneshot;
+use peniko::Color;
 use rustc_hash::FxHashMap;
 use std::future::Future;
 use std::sync::Arc;
@@ -55,14 +56,27 @@ enum RenderState {
     Active(ActiveRenderState),
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct VelloHybridRendererOptions {
     pub features: Option<Features>,
     pub limits: Option<Limits>,
     pub render_settings: RenderSettings,
+    pub base_color: Color,
     /// Alpha mode used when compositing the window surface.
     pub composite_alpha_mode: CompositeAlphaMode,
+}
+
+impl Default for VelloHybridRendererOptions {
+    fn default() -> Self {
+        Self {
+            features: None,
+            limits: None,
+            render_settings: RenderSettings::default(),
+            base_color: Color::WHITE,
+            composite_alpha_mode: CompositeAlphaMode::Auto,
+        }
+    }
 }
 
 impl VelloHybridRendererOptions {
@@ -92,6 +106,10 @@ impl VelloHybridRendererOptions {
         }
     }
 
+    pub const fn base_color(self, base_color: Color) -> Self {
+        Self { base_color, ..self }
+    }
+
     pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
         Self {
             composite_alpha_mode,
@@ -104,10 +122,10 @@ impl TryFrom<anyrender::RendererConfig> for VelloHybridRendererOptions {
     type Error = anyrender::ConfigError;
 
     fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
-        if config.base_color.is_some() {
-            return Err(anyrender::ConfigError::UnsupportedField("base_color"));
-        }
-        let mut options = Self::default();
+        let mut options = Self {
+            base_color: config.base_color.unwrap_or(Color::WHITE),
+            ..Default::default()
+        };
         if let Some(mode) = config.composite_alpha_mode {
             options.composite_alpha_mode = match mode {
                 anyrender::CompositeAlphaMode::Auto => wgpu::CompositeAlphaMode::Auto,
@@ -392,14 +410,29 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             cache: &mut self.cached_images,
         };
 
-        // Regenerate the vello scene
-        draw_fn(&mut VelloHybridScenePainter {
+        let mut scene_painter = VelloHybridScenePainter {
             scene: &mut self.scene,
             layer_stack: Vec::new(),
             image_manager,
             texture_bindings: &mut state.texture_bindings,
             device_handle: &render_surface.device_handle,
-        });
+        };
+        if self.config.base_color != Color::TRANSPARENT {
+            scene_painter.fill(
+                peniko::Fill::NonZero,
+                kurbo::Affine::IDENTITY,
+                self.config.base_color,
+                None,
+                &kurbo::Rect::new(
+                    0.,
+                    0.,
+                    render_surface.config.width as f64,
+                    render_surface.config.height as f64,
+                ),
+            );
+        }
+        // Regenerate the vello scene
+        draw_fn(&mut scene_painter);
         timer.record_time("cmd");
 
         let Ok(texture_view) = render_surface.target_texture_view() else {

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -151,9 +151,7 @@ impl VelloHybridWindowRenderer {
         Self::with_options(VelloHybridRendererOptions::default())
     }
 
-    pub fn with_options(
-        config: impl Into<VelloHybridRendererOptions>,
-    ) -> Self {
+    pub fn with_options(config: impl Into<VelloHybridRendererOptions>) -> Self {
         let config = config.into();
         let render_settings = config.render_settings;
         let wgpu_context = build_wgpu_context(&config);

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -318,9 +318,8 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             let adapter = &device_handle.adapter;
             let caps = surface.get_capabilities(adapter);
             let mut alpha_modes = caps.alpha_modes;
-            let found = alpha_modes.contains(&composite_alpha_mode);
 
-            if found {
+            if !alpha_modes.contains(&composite_alpha_mode) {
                 alpha_modes.sort_unstable_by(
                     |first: &CompositeAlphaMode, second: &CompositeAlphaMode| {
                         let first_num = match *first {

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -65,6 +65,41 @@ pub struct VelloHybridRendererOptions {
     pub composite_alpha_mode: CompositeAlphaMode,
 }
 
+impl VelloHybridRendererOptions {
+    pub fn new() -> Self {
+        // Within default of RenderSettings there are calls to non const methods so no const for new
+        Self::default()
+    }
+
+    pub const fn features(self, features: Features) -> Self {
+        Self {
+            features: Some(features),
+            ..self
+        }
+    }
+
+    pub const fn limits(self, limits: Limits) -> Self {
+        Self {
+            limits: Some(limits),
+            ..self
+        }
+    }
+
+    pub const fn render_settings(self, render_settings: RenderSettings) -> Self {
+        Self {
+            render_settings,
+            ..self
+        }
+    }
+
+    pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
+        Self {
+            composite_alpha_mode,
+            ..self
+        }
+    }
+}
+
 pub struct VelloHybridWindowRenderer {
     // The fields MUST be in this order, so that the surface is dropped before the window
     // Window is cached even when suspended so that it can be reused when the app is resumed after being suspended

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -359,12 +359,18 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             // `PostMultiplied` (straight alpha) needs conversion, which routes
             // through an intermediate texture (using the renderer's target
             // format) that is un-premultiplied while blitting to the surface.
+            #[cfg(not(target_vendor = "apple"))]
             let intermediate_texture = (composite_alpha_mode == CompositeAlphaMode::PostMultiplied)
                 .then(|| TextureConfiguration {
                     usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
                     format: DEFAULT_TEXTURE_FORMAT,
                     alpha_conversion: Some(AlphaConversion::Unpremultiply),
                 });
+
+            // Apple is almost guaranteed to be premultiplied
+            // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
+            #[cfg(target_vendor = "apple")]
+            let intermediate_texture = None;
 
             let render_surface = SurfaceRenderer::new(
                 surface,

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -1,5 +1,6 @@
 use anyrender::{
-    PaintScene, RegisterResourceErrorKind, RenderContext, ResourceId, WindowHandle, WindowRenderer,
+    CurrentCompositeAlphaMode, PaintScene, RegisterResourceErrorKind, RenderContext, ResourceId,
+    WindowHandle, WindowRenderer,
 };
 use debug_timer::debug_timer;
 use futures_channel::oneshot;
@@ -285,7 +286,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         let instance = self.wgpu_context.instance.clone();
         let extra_features = self.wgpu_context.extra_features();
         let override_limits = self.wgpu_context.override_limits();
-        let composite_alpha_mode = match self.config.composite_alpha_mode {
+        let mut composite_alpha_mode = match self.config.composite_alpha_mode {
             anyrender::CompositeAlphaMode::Auto => CompositeAlphaMode::Auto,
             anyrender::CompositeAlphaMode::Opaque => CompositeAlphaMode::Opaque,
             anyrender::CompositeAlphaMode::Transparent => {
@@ -317,6 +318,37 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                 .await
                 .expect("Error creating DeviceHandle"),
             };
+
+            let adapter = &device_handle.adapter;
+            let caps = surface.get_capabilities(adapter);
+            let mut alpha_modes = caps.alpha_modes;
+            let found = alpha_modes.iter().find(|m| **m == composite_alpha_mode);
+
+            if found.is_none() {
+                alpha_modes.sort_unstable_by(
+                    |first: &CompositeAlphaMode, second: &CompositeAlphaMode| {
+                        let first_num = match *first {
+                            CompositeAlphaMode::PreMultiplied => 0,
+                            CompositeAlphaMode::PostMultiplied => 1,
+                            CompositeAlphaMode::Opaque
+                            | CompositeAlphaMode::Inherit
+                            | CompositeAlphaMode::Auto => 2,
+                        };
+                        let second_num = match *second {
+                            CompositeAlphaMode::PreMultiplied => 0,
+                            CompositeAlphaMode::PostMultiplied => 1,
+                            CompositeAlphaMode::Opaque
+                            | CompositeAlphaMode::Inherit
+                            | CompositeAlphaMode::Auto => 2,
+                        };
+                        first_num.cmp(&second_num)
+                    },
+                );
+                composite_alpha_mode = alpha_modes
+                    .first()
+                    .copied()
+                    .expect("Surface didn't report any alpha modes");
+            }
 
             let render_surface = SurfaceRenderer::new(
                 surface,
@@ -387,6 +419,37 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             if let RenderState::Active(active) = &mut self.render_state {
                 active.render_surface.resize(width, height);
             };
+        }
+    }
+
+    fn current_alpha_mode(&self) -> Option<anyrender::CurrentCompositeAlphaMode> {
+        let RenderState::Active(state) = &self.render_state else {
+            return None;
+        };
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            match state.render_surface.surface.get_configuration()?.alpha_mode {
+                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
+                CompositeAlphaMode::PostMultiplied => {
+                    Some(CurrentCompositeAlphaMode::PostMultiplied)
+                }
+                CompositeAlphaMode::Auto
+                | CompositeAlphaMode::Opaque
+                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
+            }
+        }
+        // TODO: Remove below once gfx-rs/wgpu#9896 gets fixed
+        #[cfg(target_vendor = "apple")]
+        {
+            match state.render_surface.surface.get_configuration()?.alpha_mode {
+                CompositeAlphaMode::PreMultiplied => Some(CurrentCompositeAlphaMode::PreMultiplied),
+                CompositeAlphaMode::PostMultiplied => {
+                    Some(CurrentCompositeAlphaMode::PreMultiplied)
+                }
+                CompositeAlphaMode::Auto
+                | CompositeAlphaMode::Opaque
+                | CompositeAlphaMode::Inherit => Some(CurrentCompositeAlphaMode::Opaque),
+            }
         }
     }
 

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -56,6 +56,7 @@ enum RenderState {
 }
 
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub struct VelloHybridRendererOptions {
     pub features: Option<Features>,
     pub limits: Option<Limits>,

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -14,12 +14,9 @@ use vello_hybrid::{
 };
 use wgpu::{
     CommandEncoderDescriptor, CompositeAlphaMode, Features, Limits, PresentMode, Texture,
-    TextureFormat, TextureUsages, TextureView, TextureViewDescriptor,
+    TextureFormat, TextureView, TextureViewDescriptor,
 };
-use wgpu_context::{
-    AlphaConversion, DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration,
-    TextureConfiguration, WGPUContext,
-};
+use wgpu_context::{DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration, WGPUContext};
 
 use crate::{VelloHybridScenePainter, scene::ImageManager};
 
@@ -353,10 +350,14 @@ impl WindowRenderer for VelloHybridWindowRenderer {
             // format) that is un-premultiplied while blitting to the surface.
             #[cfg(not(target_vendor = "apple"))]
             let intermediate_texture = (composite_alpha_mode == CompositeAlphaMode::PostMultiplied)
-                .then(|| TextureConfiguration {
-                    usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
-                    format: DEFAULT_TEXTURE_FORMAT,
-                    alpha_conversion: Some(AlphaConversion::Unpremultiply),
+                .then(|| {
+                    use wgpu::TextureUsages;
+                    use wgpu_context::{AlphaConversion, TextureConfiguration};
+                    TextureConfiguration {
+                        usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                        format: DEFAULT_TEXTURE_FORMAT,
+                        alpha_conversion: Some(AlphaConversion::Unpremultiply),
+                    }
                 });
 
             // Apple is almost guaranteed to be premultiplied

--- a/crates/anyrender_vello_hybrid/src/window_renderer.rs
+++ b/crates/anyrender_vello_hybrid/src/window_renderer.rs
@@ -212,6 +212,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
         let instance = self.wgpu_context.instance.clone();
         let extra_features = self.wgpu_context.extra_features();
         let override_limits = self.wgpu_context.override_limits();
+        let composite_alpha_mode = self.config.composite_alpha_mode;
         let existing_device_handle = self
             .wgpu_context
             .find_compatible_device_handle(Some(&surface));
@@ -238,7 +239,7 @@ impl WindowRenderer for VelloHybridWindowRenderer {
                     height,
                     present_mode: PresentMode::AutoVsync,
                     desired_maximum_frame_latency: 2,
-                    alpha_mode: self.config.composite_alpha_mode,
+                    alpha_mode: composite_alpha_mode,
                     view_formats: vec![],
                 },
                 None,

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -2,7 +2,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use anyrender::{ImageRenderer, RenderContext, WindowHandle, WindowRenderer};
+use anyrender::{
+    CurrentCompositeAlphaMode, ImageRenderer, RenderContext, WindowHandle, WindowRenderer,
+};
 use debug_timer::debug_timer;
 use pixels::{
     Pixels, PixelsBuilder, SurfaceTexture,
@@ -210,6 +212,16 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
                 .unwrap();
             self.renderer.resize(physical_width, physical_height);
         };
+    }
+
+    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
+        // Pixels doesn't allow us to probe for alpha mode without ugly workarounds so we're guessing
+        Some(match self.config.composite_alpha_mode {
+            anyrender::CompositeAlphaMode::Transparent => CurrentCompositeAlphaMode::PreMultiplied,
+            anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto => {
+                CurrentCompositeAlphaMode::Opaque
+            }
+        })
     }
 
     fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(&mut self, draw_fn: F) {

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -19,12 +19,32 @@ pub enum RenderState {
     Suspended,
 }
 
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PixelsRendererOptions {
+    pub base_color: Color,
+}
+
+impl Default for PixelsRendererOptions {
+    fn default() -> Self {
+        Self {
+            base_color: Color {
+                r: 1.0,
+                g: 1.0,
+                b: 1.0,
+                a: 1.0,
+            },
+        }
+    }
+}
+
 pub struct PixelsWindowRenderer<Renderer: ImageRenderer> {
     // The fields MUST be in this order, so that the surface is dropped before the window
     // Window is cached even when suspended so that it can be reused when the app is resumed after being suspended
     render_state: RenderState,
     window_handle: Option<Arc<dyn WindowHandle>>,
     renderer: Renderer,
+    config: PixelsRendererOptions,
 }
 
 impl<Renderer: ImageRenderer> PixelsWindowRenderer<Renderer> {
@@ -38,6 +58,28 @@ impl<Renderer: ImageRenderer> PixelsWindowRenderer<Renderer> {
             render_state: RenderState::Suspended,
             window_handle: None,
             renderer,
+            config: PixelsRendererOptions::default(),
+        }
+    }
+
+    pub fn with_options(config: PixelsRendererOptions) -> Self {
+        Self {
+            render_state: RenderState::Suspended,
+            window_handle: None,
+            renderer: Renderer::new(0, 0),
+            config,
+        }
+    }
+
+    pub fn with_options_and_renderer<R: ImageRenderer>(
+        renderer: R,
+        config: PixelsRendererOptions,
+    ) -> PixelsWindowRenderer<R> {
+        PixelsWindowRenderer {
+            render_state: RenderState::Suspended,
+            window_handle: None,
+            renderer,
+            config,
         }
     }
 }
@@ -74,12 +116,7 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         let surface = SurfaceTexture::new(width, height, window_handle.clone());
         let mut pixels = Pixels::new(width, height, surface).unwrap();
         pixels.enable_vsync(true);
-        pixels.clear_color(Color {
-            r: 1.0,
-            g: 1.0,
-            b: 1.0,
-            a: 1.0,
-        });
+        pixels.clear_color(self.config.base_color);
         self.render_state = RenderState::Active(ActiveRenderState { pixels });
         self.window_handle = Some(window_handle);
 

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -62,7 +62,6 @@ impl PixelsRendererOptions {
 }
 
 impl From<anyrender::RendererConfig> for PixelsRendererOptions {
-
     fn from(config: anyrender::RendererConfig) -> Self {
         let mut options = Self::default();
         if let Some(color) = config.base_color {
@@ -102,9 +101,7 @@ impl<Renderer: ImageRenderer> PixelsWindowRenderer<Renderer> {
         }
     }
 
-    pub fn with_options(
-        config: impl Into<PixelsRendererOptions>,
-    ) -> Self {
+    pub fn with_options(config: impl Into<PixelsRendererOptions>) -> Self {
         Self {
             render_state: RenderState::Suspended,
             window_handle: None,

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -103,15 +103,13 @@ impl<Renderer: ImageRenderer> PixelsWindowRenderer<Renderer> {
     }
 
     pub fn with_options(
-        config: impl TryInto<PixelsRendererOptions, Error = impl std::error::Error>,
+        config: impl Into<PixelsRendererOptions>,
     ) -> Self {
         Self {
             render_state: RenderState::Suspended,
             window_handle: None,
             renderer: Renderer::new(0, 0),
-            config: config
-                .try_into()
-                .expect("Invalid Pixels renderer configuration"),
+            config: config.into(),
         }
     }
 

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -4,7 +4,10 @@
 
 use anyrender::{ImageRenderer, RenderContext, WindowHandle, WindowRenderer};
 use debug_timer::debug_timer;
-use pixels::{Pixels, SurfaceTexture, wgpu::Color};
+use pixels::{
+    Pixels, PixelsBuilder, SurfaceTexture,
+    wgpu::{Color, CompositeAlphaMode},
+};
 use std::sync::Arc;
 
 // Simple struct to hold the state of the renderer
@@ -23,6 +26,7 @@ pub enum RenderState {
 #[non_exhaustive]
 pub struct PixelsRendererOptions {
     pub base_color: Color,
+    pub composite_alpha_mode: CompositeAlphaMode,
 }
 
 impl Default for PixelsRendererOptions {
@@ -34,6 +38,7 @@ impl Default for PixelsRendererOptions {
                 b: 1.0,
                 a: 1.0,
             },
+            composite_alpha_mode: CompositeAlphaMode::Auto,
         }
     }
 }
@@ -114,9 +119,12 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         on_ready: F,
     ) {
         let surface = SurfaceTexture::new(width, height, window_handle.clone());
-        let mut pixels = Pixels::new(width, height, surface).unwrap();
-        pixels.enable_vsync(true);
-        pixels.clear_color(self.config.base_color);
+        let pixels = PixelsBuilder::new(width, height, surface)
+            .enable_vsync(true)
+            .alpha_mode(self.config.composite_alpha_mode)
+            .clear_color(self.config.base_color)
+            .build()
+            .unwrap();
         self.render_state = RenderState::Active(ActiveRenderState { pixels });
         self.window_handle = Some(window_handle);
 
@@ -156,7 +164,6 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         // Paint
         self.renderer.render(draw_fn, state.pixels.frame_mut());
         timer.record_time("render");
-
         state.pixels.render().unwrap();
         timer.record_time("present");
         timer.print_times("pixels: ");

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -58,6 +58,37 @@ impl PixelsRendererOptions {
     }
 }
 
+impl TryFrom<anyrender::RendererConfig> for PixelsRendererOptions {
+    type Error = anyrender::ConfigError;
+
+    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+        let mut options = Self::default();
+        if let Some(color) = config.base_color {
+            let rgba8 = color.to_rgba8();
+            options.base_color = pixels::wgpu::Color {
+                r: rgba8.r as f64 / 255.0,
+                g: rgba8.g as f64 / 255.0,
+                b: rgba8.b as f64 / 255.0,
+                a: rgba8.a as f64 / 255.0,
+            };
+        }
+        if let Some(mode) = config.composite_alpha_mode {
+            options.composite_alpha_mode = match mode {
+                anyrender::CompositeAlphaMode::Auto => pixels::wgpu::CompositeAlphaMode::Auto,
+                anyrender::CompositeAlphaMode::Opaque => pixels::wgpu::CompositeAlphaMode::Opaque,
+                anyrender::CompositeAlphaMode::PreMultiplied => {
+                    pixels::wgpu::CompositeAlphaMode::PreMultiplied
+                }
+                anyrender::CompositeAlphaMode::PostMultiplied => {
+                    pixels::wgpu::CompositeAlphaMode::PostMultiplied
+                }
+                anyrender::CompositeAlphaMode::Inherit => pixels::wgpu::CompositeAlphaMode::Inherit,
+            };
+        }
+        Ok(options)
+    }
+}
+
 pub struct PixelsWindowRenderer<Renderer: ImageRenderer> {
     // The fields MUST be in this order, so that the surface is dropped before the window
     // Window is cached even when suspended so that it can be reused when the app is resumed after being suspended
@@ -82,24 +113,30 @@ impl<Renderer: ImageRenderer> PixelsWindowRenderer<Renderer> {
         }
     }
 
-    pub fn with_options(config: PixelsRendererOptions) -> Self {
+    pub fn with_options(
+        config: impl TryInto<PixelsRendererOptions, Error = impl std::error::Error>,
+    ) -> Self {
         Self {
             render_state: RenderState::Suspended,
             window_handle: None,
             renderer: Renderer::new(0, 0),
-            config,
+            config: config
+                .try_into()
+                .expect("Invalid Pixels renderer configuration"),
         }
     }
 
     pub fn with_options_and_renderer<R: ImageRenderer>(
         renderer: R,
-        config: PixelsRendererOptions,
+        config: impl TryInto<PixelsRendererOptions, Error = impl std::error::Error>,
     ) -> PixelsWindowRenderer<R> {
         PixelsWindowRenderer {
             render_state: RenderState::Suspended,
             window_handle: None,
             renderer,
-            config,
+            config: config
+                .try_into()
+                .expect("Invalid Pixels renderer configuration"),
         }
     }
 }

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -29,7 +29,7 @@ pub struct PixelsRendererOptions {
     /// Background color used to clear the frame.
     pub base_color: Color,
     /// Alpha mode used when compositing the window surface.
-    pub composite_alpha_mode: CompositeAlphaMode,
+    pub composite_alpha_mode: anyrender::CompositeAlphaMode,
 }
 
 impl Default for PixelsRendererOptions {
@@ -42,7 +42,7 @@ impl PixelsRendererOptions {
     pub const fn new() -> Self {
         Self {
             base_color: Color::WHITE,
-            composite_alpha_mode: CompositeAlphaMode::Auto,
+            composite_alpha_mode: anyrender::CompositeAlphaMode::Auto,
         }
     }
 
@@ -50,7 +50,10 @@ impl PixelsRendererOptions {
         Self { base_color, ..self }
     }
 
-    pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
+    pub const fn composite_alpha_mode(
+        self,
+        composite_alpha_mode: anyrender::CompositeAlphaMode,
+    ) -> Self {
         Self {
             composite_alpha_mode,
             ..self
@@ -72,20 +75,7 @@ impl TryFrom<anyrender::RendererConfig> for PixelsRendererOptions {
                 a: rgba8.a as f64 / 255.0,
             };
         }
-        if let Some(mode) = config.composite_alpha_mode {
-            options.composite_alpha_mode = match mode {
-                anyrender::CompositeAlphaMode::Auto => pixels::wgpu::CompositeAlphaMode::Auto,
-                anyrender::CompositeAlphaMode::Opaque => pixels::wgpu::CompositeAlphaMode::Opaque,
-                anyrender::CompositeAlphaMode::PreMultiplied => {
-                    pixels::wgpu::CompositeAlphaMode::PreMultiplied
-                }
-                anyrender::CompositeAlphaMode::PostMultiplied => {
-                    pixels::wgpu::CompositeAlphaMode::PostMultiplied
-                }
-                anyrender::CompositeAlphaMode::Inherit => pixels::wgpu::CompositeAlphaMode::Inherit,
-            };
-        }
-        Ok(options)
+        Ok(options.composite_alpha_mode(config.composite_alpha_mode.unwrap_or_default()))
     }
 }
 
@@ -170,10 +160,26 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
         height: u32,
         on_ready: F,
     ) {
+        let composite_alpha_mode = match self.config.composite_alpha_mode {
+            anyrender::CompositeAlphaMode::Auto => CompositeAlphaMode::Auto,
+            anyrender::CompositeAlphaMode::Opaque => CompositeAlphaMode::Opaque,
+            anyrender::CompositeAlphaMode::Transparent => {
+                #[cfg(target_vendor = "apple")]
+                {
+                    // wgpu is lying in apple's case it uses PreMultiplied in reality
+                    // (do not modify shaders for PostMultiplied)
+                    CompositeAlphaMode::PostMultiplied
+                }
+                #[cfg(not(target_vendor = "apple"))]
+                {
+                    CompositeAlphaMode::PreMultiplied
+                }
+            }
+        };
         let surface = SurfaceTexture::new(width, height, window_handle.clone());
         let pixels = PixelsBuilder::new(width, height, surface)
             .enable_vsync(true)
-            .alpha_mode(self.config.composite_alpha_mode)
+            .alpha_mode(composite_alpha_mode)
             .clear_color(self.config.base_color)
             .build()
             .unwrap();

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -34,14 +34,26 @@ pub struct PixelsRendererOptions {
 
 impl Default for PixelsRendererOptions {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PixelsRendererOptions {
+    pub const fn new() -> Self {
         Self {
-            base_color: Color {
-                r: 1.0,
-                g: 1.0,
-                b: 1.0,
-                a: 1.0,
-            },
+            base_color: Color::WHITE,
             composite_alpha_mode: CompositeAlphaMode::Auto,
+        }
+    }
+
+    pub const fn base_color(self, base_color: Color) -> Self {
+        Self { base_color, ..self }
+    }
+
+    pub const fn composite_alpha_mode(self, composite_alpha_mode: CompositeAlphaMode) -> Self {
+        Self {
+            composite_alpha_mode,
+            ..self
         }
     }
 }

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -2,9 +2,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use anyrender::{
-    CurrentCompositeAlphaMode, ImageRenderer, RenderContext, WindowHandle, WindowRenderer,
-};
+use anyrender::{ImageRenderer, RenderContext, WindowHandle, WindowRenderer};
 use debug_timer::debug_timer;
 use pixels::{
     Pixels, PixelsBuilder, SurfaceTexture,
@@ -212,16 +210,6 @@ impl<Renderer: ImageRenderer> WindowRenderer for PixelsWindowRenderer<Renderer> 
                 .unwrap();
             self.renderer.resize(physical_width, physical_height);
         };
-    }
-
-    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
-        // Pixels doesn't allow us to probe for alpha mode without ugly workarounds so we're guessing
-        Some(match self.config.composite_alpha_mode {
-            anyrender::CompositeAlphaMode::Transparent => CurrentCompositeAlphaMode::PreMultiplied,
-            anyrender::CompositeAlphaMode::Opaque | anyrender::CompositeAlphaMode::Auto => {
-                CurrentCompositeAlphaMode::Opaque
-            }
-        })
     }
 
     fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(&mut self, draw_fn: F) {

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -61,10 +61,9 @@ impl PixelsRendererOptions {
     }
 }
 
-impl TryFrom<anyrender::RendererConfig> for PixelsRendererOptions {
-    type Error = anyrender::ConfigError;
+impl From<anyrender::RendererConfig> for PixelsRendererOptions {
 
-    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+    fn from(config: anyrender::RendererConfig) -> Self {
         let mut options = Self::default();
         if let Some(color) = config.base_color {
             let rgba8 = color.to_rgba8();
@@ -75,7 +74,7 @@ impl TryFrom<anyrender::RendererConfig> for PixelsRendererOptions {
                 a: rgba8.a as f64 / 255.0,
             };
         }
-        Ok(options.composite_alpha_mode(config.composite_alpha_mode.unwrap_or_default()))
+        options.composite_alpha_mode(config.composite_alpha_mode.unwrap_or_default())
     }
 }
 

--- a/crates/pixels_window_renderer/src/lib.rs
+++ b/crates/pixels_window_renderer/src/lib.rs
@@ -22,10 +22,13 @@ pub enum RenderState {
     Suspended,
 }
 
+/// Configuration options for the Pixels renderer.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct PixelsRendererOptions {
+    /// Background color used to clear the frame.
     pub base_color: Color,
+    /// Alpha mode used when compositing the window surface.
     pub composite_alpha_mode: CompositeAlphaMode,
 }
 

--- a/crates/softbuffer_window_renderer/Cargo.toml
+++ b/crates/softbuffer_window_renderer/Cargo.toml
@@ -16,3 +16,4 @@ anyrender = { workspace = true }
 debug_timer = { workspace = true }
 softbuffer = { workspace = true }
 peniko = { workspace = true }
+kurbo = { workspace = true }

--- a/crates/softbuffer_window_renderer/Cargo.toml
+++ b/crates/softbuffer_window_renderer/Cargo.toml
@@ -15,3 +15,4 @@ log_frame_times = ["debug_timer/enable"]
 anyrender = { workspace = true }
 debug_timer = { workspace = true }
 softbuffer = { workspace = true }
+peniko = { workspace = true }

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -2,9 +2,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use anyrender::{
-    CurrentCompositeAlphaMode, ImageRenderer, RenderContext, WindowHandle, WindowRenderer,
-};
+use anyrender::{ImageRenderer, RenderContext, WindowHandle, WindowRenderer};
 use debug_timer::debug_timer;
 use softbuffer::{Context, Surface};
 use std::{num::NonZero, sync::Arc};
@@ -175,10 +173,6 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
                 .unwrap();
             self.renderer.resize(physical_width, physical_height);
         };
-    }
-
-    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
-        Some(CurrentCompositeAlphaMode::Opaque)
     }
 
     fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(&mut self, draw_fn: F) {

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -2,7 +2,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use anyrender::{ImageRenderer, RenderContext, WindowHandle, WindowRenderer};
+use anyrender::{
+    CurrentCompositeAlphaMode, ImageRenderer, RenderContext, WindowHandle, WindowRenderer,
+};
 use debug_timer::debug_timer;
 use softbuffer::{Context, Surface};
 use std::{num::NonZero, sync::Arc};
@@ -173,6 +175,10 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
                 .unwrap();
             self.renderer.resize(physical_width, physical_height);
         };
+    }
+
+    fn current_alpha_mode(&self) -> Option<CurrentCompositeAlphaMode> {
+        Some(CurrentCompositeAlphaMode::Opaque)
     }
 
     fn render<F: FnOnce(&mut Renderer::ScenePainter<'_>)>(&mut self, draw_fn: F) {

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -106,8 +106,7 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
             window_handle: None,
             renderer: Renderer::new(0, 0),
             buffer: Vec::new(),
-            config: config
-                .try_into()?,
+            config: config.try_into()?,
             width: 0,
             height: 0,
         })

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -34,25 +34,15 @@ impl SoftbufferRendererOptions {
     }
 }
 
-impl TryFrom<anyrender::RendererConfig> for SoftbufferRendererOptions {
-    type Error = anyrender::ConfigError;
-
-    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+impl From<anyrender::RendererConfig> for SoftbufferRendererOptions {
+    fn from(config: anyrender::RendererConfig) -> Self {
         let mut options = Self::default();
         if let Some(color) = config.base_color {
             options.base_color = color;
         }
-        if let Some(composite_alpha_mode) = config.composite_alpha_mode {
-            match composite_alpha_mode {
-                anyrender::CompositeAlphaMode::Auto | anyrender::CompositeAlphaMode::Opaque => {}
-                _ => {
-                    return Err(anyrender::ConfigError::UnsupportedField(
-                        "composite_alpha_mode",
-                    ));
-                }
-            }
-        }
-        Ok(options)
+        // `composite_alpha_mode` is intentionally ignored: softbuffer does not
+        // support transparency, so any requested alpha mode degrades to opaque.
+        options
     }
 }
 
@@ -93,6 +83,18 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
             renderer,
             buffer: Vec::new(),
             config: SoftbufferRendererOptions::default(),
+            width: 0,
+            height: 0,
+        }
+    }
+
+    pub fn with_options(config: impl Into<SoftbufferRendererOptions>) -> Self {
+        Self {
+            render_state: RenderState::Suspended,
+            window_handle: None,
+            renderer: Renderer::new(0, 0),
+            buffer: Vec::new(),
+            config: config.into(),
             width: 0,
             height: 0,
         }

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -2,8 +2,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use anyrender::{ImageRenderer, RenderContext, WindowHandle, WindowRenderer};
+use anyrender::{ImageRenderer, PaintScene, RenderContext, WindowHandle, WindowRenderer};
 use debug_timer::debug_timer;
+use kurbo::{Affine, Rect};
 use softbuffer::{Context, Surface};
 use std::{num::NonZero, sync::Arc};
 
@@ -65,6 +66,8 @@ pub struct SoftbufferWindowRenderer<Renderer: ImageRenderer> {
     renderer: Renderer,
     buffer: Vec<u8>,
     config: SoftbufferRendererOptions,
+    width: u32,
+    height: u32,
 }
 
 impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
@@ -80,6 +83,8 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
             renderer,
             buffer: Vec::new(),
             config: SoftbufferRendererOptions::default(),
+            width: 0,
+            height: 0,
         }
     }
 
@@ -94,6 +99,8 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
             config: config
                 .try_into()
                 .expect("Invalid Softbuffer renderer configuration"),
+            width: 0,
+            height: 0,
         }
     }
 
@@ -109,6 +116,8 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
             config: config
                 .try_into()
                 .expect("Invalid Softbuffer renderer configuration"),
+            width: 0,
+            height: 0,
         }
     }
 }
@@ -163,6 +172,8 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
     }
 
     fn set_size(&mut self, physical_width: u32, physical_height: u32) {
+        self.width = physical_width;
+        self.height = physical_height;
         if let RenderState::Active(state) = &mut self.render_state {
             state
                 .surface
@@ -188,7 +199,23 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         timer.record_time("buffer_mut");
 
         // Paint
-        self.renderer.render_to_vec(draw_fn, &mut self.buffer);
+        let base_color = self.config.base_color;
+        let width = self.width as f64;
+        let height = self.height as f64;
+
+        let wrapped_draw_fn = |painter: &mut Renderer::ScenePainter<'_>| {
+            painter.fill(
+                peniko::Fill::NonZero,
+                Affine::IDENTITY,
+                base_color,
+                None,
+                &Rect::new(0.0, 0.0, width, height),
+            );
+            draw_fn(painter);
+        };
+
+        self.renderer
+            .render_to_vec(wrapped_draw_fn, &mut self.buffer);
         timer.record_time("render");
 
         let out = surface_buffer.as_mut();
@@ -197,48 +224,13 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         assert_eq!(chunks.len(), out.len());
         assert_eq!(remainder.len(), 0);
 
-        let base_color = self.config.base_color.to_rgba8();
-        let base_r = base_color.r as u32;
-        let base_g = base_color.g as u32;
-        let base_b = base_color.b as u32;
-        let base_a = base_color.a as u32;
-
         for (&src, dest) in chunks.iter().zip(out.iter_mut()) {
-            let [r, g, b, a] = src;
+            let [r, g, b, _a] = src;
             let r = r as u32;
             let g = g as u32;
             let b = b as u32;
-            let a = a as u32;
 
-            let out_r: u32;
-            let out_g: u32;
-            let out_b: u32;
-
-            if a < 255 {
-                let out_a = a + (base_a * (255 - a)) / 255;
-
-                if out_a > 0 {
-                    // Pre-multiply common factor to keep it clean and performant
-                    let denom = out_a * 255;
-                    let blend_factor = base_a * (255 - a);
-
-                    out_r = (r * a * 255 + base_r * blend_factor) / denom;
-                    out_g = (g * a * 255 + base_g * blend_factor) / denom;
-                    out_b = (b * a * 255 + base_b * blend_factor) / denom;
-                } else {
-                    // Both source and base are completely transparent (out_a == 0)
-                    out_r = 0;
-                    out_g = 0;
-                    out_b = 0;
-                }
-            } else {
-                // Source is fully opaque, no blending required
-                out_r = r;
-                out_g = g;
-                out_b = b;
-            }
-
-            *dest = (out_r << 16) | (out_g << 8) | out_b;
+            *dest = (r << 16) | (g << 8) | b;
         }
         timer.record_time("swizel");
 

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -42,6 +42,16 @@ impl TryFrom<anyrender::RendererConfig> for SoftbufferRendererOptions {
         if let Some(color) = config.base_color {
             options.base_color = color;
         }
+        if let Some(composite_alpha_mode) = config.composite_alpha_mode {
+            match composite_alpha_mode {
+                anyrender::CompositeAlphaMode::Auto | anyrender::CompositeAlphaMode::Opaque => {}
+                _ => {
+                    return Err(anyrender::ConfigError::UnsupportedField(
+                        "composite_alpha_mode",
+                    ));
+                }
+            }
+        }
         Ok(options)
     }
 }

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -7,6 +7,44 @@ use debug_timer::debug_timer;
 use softbuffer::{Context, Surface};
 use std::{num::NonZero, sync::Arc};
 
+/// Configuration options for the Softbuffer renderer.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SoftbufferRendererOptions {
+    /// Background color used to clear the frame.
+    pub base_color: peniko::Color,
+}
+
+impl Default for SoftbufferRendererOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SoftbufferRendererOptions {
+    pub const fn new() -> Self {
+        Self {
+            base_color: peniko::Color::WHITE,
+        }
+    }
+
+    pub const fn base_color(self, base_color: peniko::Color) -> Self {
+        Self { base_color, ..self }
+    }
+}
+
+impl TryFrom<anyrender::RendererConfig> for SoftbufferRendererOptions {
+    type Error = anyrender::ConfigError;
+
+    fn try_from(config: anyrender::RendererConfig) -> Result<Self, Self::Error> {
+        let mut options = Self::default();
+        if let Some(color) = config.base_color {
+            options.base_color = color;
+        }
+        Ok(options)
+    }
+}
+
 // Simple struct to hold the state of the renderer
 pub struct ActiveRenderState {
     _context: Context<Arc<dyn WindowHandle>>,
@@ -26,6 +64,7 @@ pub struct SoftbufferWindowRenderer<Renderer: ImageRenderer> {
     window_handle: Option<Arc<dyn WindowHandle>>,
     renderer: Renderer,
     buffer: Vec<u8>,
+    config: SoftbufferRendererOptions,
 }
 
 impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
@@ -40,6 +79,36 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
             window_handle: None,
             renderer,
             buffer: Vec::new(),
+            config: SoftbufferRendererOptions::default(),
+        }
+    }
+
+    pub fn with_options(
+        config: impl TryInto<SoftbufferRendererOptions, Error = impl std::error::Error>,
+    ) -> Self {
+        Self {
+            render_state: RenderState::Suspended,
+            window_handle: None,
+            renderer: Renderer::new(0, 0),
+            buffer: Vec::new(),
+            config: config
+                .try_into()
+                .expect("Invalid Softbuffer renderer configuration"),
+        }
+    }
+
+    pub fn with_options_and_renderer<R: ImageRenderer>(
+        renderer: R,
+        config: impl TryInto<SoftbufferRendererOptions, Error = impl std::error::Error>,
+    ) -> SoftbufferWindowRenderer<R> {
+        SoftbufferWindowRenderer {
+            render_state: RenderState::Suspended,
+            window_handle: None,
+            renderer,
+            buffer: Vec::new(),
+            config: config
+                .try_into()
+                .expect("Invalid Softbuffer renderer configuration"),
         }
     }
 }
@@ -128,13 +197,48 @@ impl<Renderer: ImageRenderer> WindowRenderer for SoftbufferWindowRenderer<Render
         assert_eq!(chunks.len(), out.len());
         assert_eq!(remainder.len(), 0);
 
+        let base_color = self.config.base_color.to_rgba8();
+        let base_r = base_color.r as u32;
+        let base_g = base_color.g as u32;
+        let base_b = base_color.b as u32;
+        let base_a = base_color.a as u32;
+
         for (&src, dest) in chunks.iter().zip(out.iter_mut()) {
             let [r, g, b, a] = src;
-            if a == 0 {
-                *dest = u32::MAX;
+            let r = r as u32;
+            let g = g as u32;
+            let b = b as u32;
+            let a = a as u32;
+
+            let out_r: u32;
+            let out_g: u32;
+            let out_b: u32;
+
+            if a < 255 {
+                let out_a = a + (base_a * (255 - a)) / 255;
+
+                if out_a > 0 {
+                    // Pre-multiply common factor to keep it clean and performant
+                    let denom = out_a * 255;
+                    let blend_factor = base_a * (255 - a);
+
+                    out_r = (r * a * 255 + base_r * blend_factor) / denom;
+                    out_g = (g * a * 255 + base_g * blend_factor) / denom;
+                    out_b = (b * a * 255 + base_b * blend_factor) / denom;
+                } else {
+                    // Both source and base are completely transparent (out_a == 0)
+                    out_r = 0;
+                    out_g = 0;
+                    out_b = 0;
+                }
             } else {
-                *dest = (r as u32) << 16 | (g as u32) << 8 | b as u32;
+                // Source is fully opaque, no blending required
+                out_r = r;
+                out_g = g;
+                out_b = b;
             }
+
+            *dest = (out_r << 16) | (out_g << 8) | out_b;
         }
         timer.record_time("swizel");
 

--- a/crates/softbuffer_window_renderer/src/lib.rs
+++ b/crates/softbuffer_window_renderer/src/lib.rs
@@ -98,20 +98,19 @@ impl<Renderer: ImageRenderer> SoftbufferWindowRenderer<Renderer> {
         }
     }
 
-    pub fn with_options(
-        config: impl TryInto<SoftbufferRendererOptions, Error = impl std::error::Error>,
-    ) -> Self {
-        Self {
+    pub fn try_with_options<E: std::error::Error>(
+        config: impl TryInto<SoftbufferRendererOptions, Error = E>,
+    ) -> Result<Self, E> {
+        Ok(Self {
             render_state: RenderState::Suspended,
             window_handle: None,
             renderer: Renderer::new(0, 0),
             buffer: Vec::new(),
             config: config
-                .try_into()
-                .expect("Invalid Softbuffer renderer configuration"),
+                .try_into()?,
             width: 0,
             height: 0,
-        }
+        })
     }
 
     pub fn with_options_and_renderer<R: ImageRenderer>(

--- a/crates/wgpu_context/src/alpha_blitter.rs
+++ b/crates/wgpu_context/src/alpha_blitter.rs
@@ -1,0 +1,193 @@
+//! A blitter that converts between premultiplied and straight
+//! (non-premultiplied) alpha while copying one texture into another.
+//!
+//! This is needed when the alpha representation of a renderer's output does not
+//! match what the window surface expects:
+//!
+//! - A [`wgpu::CompositeAlphaMode::PostMultiplied`] surface expects *straight*
+//!   alpha, because the OS compositor multiplies the colour by alpha itself.
+//! - A [`wgpu::CompositeAlphaMode::PreMultiplied`] surface expects colour that
+//!   has *already* been multiplied by alpha.
+//!
+//! Renderers differ: Vello Hybrid emits premultiplied alpha, whereas Vello
+//! Classic emits straight alpha. Feeding the wrong representation to a surface
+//! either darkens (premultiplied into PostMultiplied) or brightens (straight
+//! into PreMultiplied) partially-transparent pixels. This blitter applies the
+//! matching correction (`rgb / a` or `rgb * a`) while copying.
+
+use wgpu::{
+    BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
+    BindGroupLayoutEntry, BindingResource, BindingType, ColorTargetState, ColorWrites,
+    CommandEncoder, Device, FragmentState, LoadOp, MultisampleState, Operations,
+    PipelineLayoutDescriptor, PrimitiveState, RenderPassColorAttachment, RenderPassDescriptor,
+    RenderPipeline, RenderPipelineDescriptor, ShaderStages, StoreOp, TextureFormat,
+    TextureSampleType, TextureView, TextureViewDimension, VertexState,
+};
+
+/// The direction of alpha conversion to apply while blitting.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AlphaConversion {
+    /// Convert straight alpha to premultiplied (`rgb * a`). Use when the
+    /// renderer emits straight alpha and the surface expects premultiplied
+    /// (i.e. [`wgpu::CompositeAlphaMode::PreMultiplied`]).
+    Premultiply,
+    /// Convert premultiplied alpha to straight (`rgb / a`). Use when the
+    /// renderer emits premultiplied alpha and the surface expects straight
+    /// (i.e. [`wgpu::CompositeAlphaMode::PostMultiplied`]).
+    Unpremultiply,
+}
+
+const SHADER: &str = r#"
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+};
+
+// Fullscreen triangle: 3 vertices covering the whole clip space.
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var out: VertexOutput;
+    let x = f32((vertex_index << 1u) & 2u);
+    let y = f32(vertex_index & 2u);
+    out.position = vec4<f32>(x * 2.0 - 1.0, 1.0 - y * 2.0, 0.0, 1.0);
+    return out;
+}
+
+@group(0) @binding(0) var src: texture_2d<f32>;
+
+// Premultiplied alpha -> straight alpha.
+@fragment
+fn fs_unpremultiply(in: VertexOutput) -> @location(0) vec4<f32> {
+    let c = textureLoad(src, vec2<i32>(in.position.xy), 0);
+    let a = c.a;
+    var rgb = vec3<f32>(0.0, 0.0, 0.0);
+    if (a > 0.0) {
+        rgb = c.rgb / a;
+    }
+    return vec4<f32>(rgb, a);
+}
+
+// Straight alpha -> premultiplied alpha.
+@fragment
+fn fs_premultiply(in: VertexOutput) -> @location(0) vec4<f32> {
+    let c = textureLoad(src, vec2<i32>(in.position.xy), 0);
+    return vec4<f32>(c.rgb * c.a, c.a);
+}
+"#;
+
+/// Blits a texture into another texture, converting between premultiplied and
+/// straight alpha in the process.
+///
+/// Mirrors the API of [`wgpu::util::TextureBlitter`] so it can be used as a
+/// drop-in replacement.
+pub struct AlphaConvertBlitter {
+    pipeline: RenderPipeline,
+    bind_group_layout: BindGroupLayout,
+}
+
+impl AlphaConvertBlitter {
+    /// Create a blitter that applies `conversion` and writes to a target
+    /// texture of the given `format`.
+    pub fn new(device: &Device, format: TextureFormat, conversion: AlphaConversion) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("alpha convert blit shader"),
+            source: wgpu::ShaderSource::Wgsl(SHADER.into()),
+        });
+
+        let entry_point = match conversion {
+            AlphaConversion::Premultiply => "fs_premultiply",
+            AlphaConversion::Unpremultiply => "fs_unpremultiply",
+        };
+
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("alpha convert blit bind group layout"),
+            entries: &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    sample_type: TextureSampleType::Float { filterable: false },
+                    view_dimension: TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("alpha convert blit pipeline layout"),
+            bind_group_layouts: &[Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("alpha convert blit pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(FragmentState {
+                module: &shader,
+                entry_point: Some(entry_point),
+                compilation_options: Default::default(),
+                targets: &[Some(ColorTargetState {
+                    format,
+                    blend: None,
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+            primitive: PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            bind_group_layout,
+        }
+    }
+
+    /// Copy `source` into `target`, applying the alpha conversion.
+    ///
+    /// `source` and `target` must have the same dimensions.
+    pub fn copy(
+        &self,
+        device: &Device,
+        encoder: &mut CommandEncoder,
+        source: &TextureView,
+        target: &TextureView,
+    ) {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("alpha convert blit bind group"),
+            layout: &self.bind_group_layout,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: BindingResource::TextureView(source),
+            }],
+        });
+
+        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("alpha convert blit pass"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+}

--- a/crates/wgpu_context/src/lib.rs
+++ b/crates/wgpu_context/src/lib.rs
@@ -7,11 +7,13 @@ use wgpu::{
     Adapter, Device, Features, Instance, Limits, MemoryHints, Queue, Surface, SurfaceTarget,
 };
 
+mod alpha_blitter;
 mod buffer_renderer;
 mod error;
 mod surface_renderer;
 mod util;
 
+pub use alpha_blitter::{AlphaConversion, AlphaConvertBlitter};
 pub use buffer_renderer::{BufferRenderer, BufferRendererConfig};
 pub use error::WgpuContextError;
 pub use surface_renderer::{SurfaceRenderer, SurfaceRendererConfiguration, TextureConfiguration};

--- a/crates/wgpu_context/src/surface_renderer.rs
+++ b/crates/wgpu_context/src/surface_renderer.rs
@@ -1,4 +1,6 @@
-use crate::{DeviceHandle, WgpuContextError, util::create_texture};
+use crate::{
+    AlphaConversion, AlphaConvertBlitter, DeviceHandle, WgpuContextError, util::create_texture,
+};
 use wgpu::{
     CommandEncoderDescriptor, CompositeAlphaMode, CurrentSurfaceTexture, Device, PresentMode,
     Queue, Surface, SurfaceConfiguration, SurfaceTexture, TextureFormat, TextureUsages,
@@ -12,6 +14,42 @@ pub struct GetCurrentSurfaceTextureErr;
 #[derive(Clone)]
 pub struct TextureConfiguration {
     pub usage: TextureUsages,
+    /// Format of the intermediate texture. This must match the format that the
+    /// renderer targets when rendering into the intermediate texture.
+    pub format: TextureFormat,
+    /// Alpha conversion to apply while blitting the intermediate texture to the
+    /// surface. `None` performs a straight copy.
+    ///
+    /// This is renderer- and surface-specific. It must be set based on the
+    /// alpha representation the renderer emits (premultiplied vs straight) and
+    /// what the surface's [`CompositeAlphaMode`] expects. For example, a
+    /// premultiplied-alpha renderer targeting a `PostMultiplied` surface uses
+    /// [`AlphaConversion::Unpremultiply`], while a straight-alpha renderer
+    /// targeting a `PreMultiplied` surface uses [`AlphaConversion::Premultiply`].
+    pub alpha_conversion: Option<AlphaConversion>,
+}
+
+/// How the intermediate texture is blitted to the surface texture.
+enum IntermediateBlitter {
+    /// Straight copy (source and destination alpha are treated identically).
+    Copy(TextureBlitter),
+    /// Convert between premultiplied and straight alpha while copying.
+    Convert(AlphaConvertBlitter),
+}
+
+impl IntermediateBlitter {
+    fn copy(
+        &self,
+        device: &Device,
+        encoder: &mut wgpu::CommandEncoder,
+        source: &TextureView,
+        target: &TextureView,
+    ) {
+        match self {
+            IntermediateBlitter::Copy(blitter) => blitter.copy(device, encoder, source, target),
+            IntermediateBlitter::Convert(blitter) => blitter.copy(device, encoder, source, target),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -77,7 +115,7 @@ struct IntermediateTextureStuff {
     // from the TextureView so we don't need to store both.
     pub texture_view: TextureView,
     // Blitter for blitting from the intermediate texture to the surface.
-    pub blitter: TextureBlitter,
+    pub blitter: IntermediateBlitter,
 }
 
 /// Combination of surface and its configuration.
@@ -129,16 +167,29 @@ impl<'s> SurfaceRenderer<'s> {
         };
 
         let intermediate_texture = intermediate_texture_config.map(|texture_config| {
+            // Apply the requested alpha conversion while blitting, or a straight
+            // copy when no conversion is needed.
+            let blitter = match texture_config.alpha_conversion {
+                Some(conversion) => IntermediateBlitter::Convert(AlphaConvertBlitter::new(
+                    &device_handle.device,
+                    surface_config.format,
+                    conversion,
+                )),
+                None => IntermediateBlitter::Copy(TextureBlitter::new(
+                    &device_handle.device,
+                    surface_config.format,
+                )),
+            };
             Box::new(IntermediateTextureStuff {
                 config: texture_config.clone(),
                 texture_view: create_texture(
                     surface_renderer_config.width,
                     surface_renderer_config.height,
-                    TextureFormat::Rgba8Unorm,
+                    texture_config.format,
                     texture_config.usage,
                     &device_handle.device,
                 ),
-                blitter: TextureBlitter::new(&device_handle.device, surface_config.format),
+                blitter,
             })
         });
 
@@ -169,7 +220,7 @@ impl<'s> SurfaceRenderer<'s> {
             intermediate_texture_stuff.texture_view = create_texture(
                 width,
                 height,
-                TextureFormat::Rgba8Unorm,
+                intermediate_texture_stuff.config.format,
                 intermediate_texture_stuff.config.usage,
                 &self.device_handle.device,
             );


### PR DESCRIPTION
Re-open of https://github.com/DioxusLabs/anyrender/pull/70

## Summary

This pull request introduces the ability to configure composite alpha modes and base colors across various renderers. Previously, the composite alpha mode was hardcoded (e.g. to `Auto`, which often defaults to `Opaque`), making alpha-blending and transparency difficult or impossible.

We now expose configurable option structs and allow specifying the background/clear colors and composite alpha modes for Vello, Vello Hybrid, Skia, and Pixels (CPU) renderers. Additionally, we make key options structs future-proof by marking them as `#[non_exhaustive]`.

> [!NOTE]
> `softbuffer` does not support transparency natively (yet), so these alpha-compositing features will apply only to the GPU and Pixels-based paths.
>
> A small adjustment will need to be made in `dioxus-native` to use struct updates or `Default::default()` when constructing renderer options to accommodate the `#[non_exhaustive]` attribute.

## Key Changes

### 1. Transparency & Alpha Compositing Control

- **Vello Renderers**: Added `composite_alpha_mode` option to vello's `window_renderer.rs` and vello-hybrid's `window_renderer.rs`. This controls the surface compositing behavior of the WGPU surface inside the respective window renderers.
- **Pixels CPU / Raster Renderers**: Added configuration options via the `PixelsRendererOptions` struct inside `lib.rs` to customize the `base_color` and `composite_alpha_mode` using the `PixelsBuilder` API.
- **Skia Renderer**: Added configuration options via the `SkiaRendererOptions` inside `window_renderer.rs` to customize the `base_color` only as Skia handles transparency by default.
- **Skia Raster Renderer**: Clears the canvas with `Color::TRANSPARENT` in `image_renderer.rs` by default to preserve alpha channels in rendered outputs.

### 2. Extensibility & Future Proofing

- Marked options in vello's `window_renderer.rs` and vello-hybrid's `window_renderer.rs` as `#[non_exhaustive]` to allow adding more configuration fields in the future without breaking user builds.

### 3. Crate-specific Options & Structs

- **`anyrender_vello_cpu`**: Exported `VelloCpuRendererOptions` as an alias for `PixelsRendererOptions`.
- **`anyrender_skia`**: Exported `SkiaRasterRendererOptions` as an alias for `PixelsRendererOptions`.

## Breaking Changes

- The configuration structs `VelloRendererOptions` and `VelloHybridRendererOptions` are now `#[non_exhaustive]`. Constructing these structs directly without using `Default::default()` or struct update syntax will cause compilation errors.

<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/anyrender/pull/71?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/anyrender/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->