### PR TITLE
Let a wgpu PipelineCache reach Vello

### DIFF
--- a/crates/anyrender_vello/CHANGELOG.md
+++ b/crates/anyrender_vello/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configurable composite alpha mode and base color via `VelloRendererOptions`, with builder-pattern methods (#71).
+- `pipeline_cache` on `VelloRendererOptions`, and `VelloImageRenderer::with_pipeline_cache`, so a `wgpu::PipelineCache` can reach Vello (#73).
 
 ### Changed
 
 - Marked `VelloRendererOptions` as `#[non_exhaustive]` (#71).
+- `VelloRendererOptions`' builder methods are no longer `const`, because the options now hold a type with a destructor (#73).
 
 ## [0.12.0] - 2026-06-23
 

--- a/crates/anyrender_vello/src/image_renderer.rs
+++ b/crates/anyrender_vello/src/image_renderer.rs
@@ -14,14 +14,15 @@ pub struct VelloImageRenderer {
     texture_handles: FxHashMap<ResourceId, ImageData>,
 }
 
-impl RenderContext for VelloImageRenderer {}
-impl ImageRenderer for VelloImageRenderer {
-    type ScenePainter<'a>
-        = VelloScenePainter<'a, 'a>
-    where
-        Self: 'a;
-
-    fn new(width: u32, height: u32) -> Self {
+impl VelloImageRenderer {
+    /// Like [`ImageRenderer::new`], but reusing compiled pipelines from a cache
+    /// wgpu built earlier. Creating the cache, persisting its data and deciding
+    /// when it is stale are all the caller's responsibility.
+    pub fn with_pipeline_cache(
+        width: u32,
+        height: u32,
+        pipeline_cache: Option<wgpu::PipelineCache>,
+    ) -> Self {
         // Create WGPUContext
         let mut context = WGPUContext::new();
 
@@ -41,7 +42,7 @@ impl ImageRenderer for VelloImageRenderer {
                 use_cpu: false,
                 num_init_threads: DEFAULT_THREADS,
                 antialiasing_support: vello::AaSupport::area_only(),
-                pipeline_cache: None,
+                pipeline_cache,
             },
         )
         .expect("Got non-Send/Sync error from creating renderer");
@@ -52,6 +53,18 @@ impl ImageRenderer for VelloImageRenderer {
             scene: VelloScene::new(),
             texture_handles: FxHashMap::default(),
         }
+    }
+}
+
+impl RenderContext for VelloImageRenderer {}
+impl ImageRenderer for VelloImageRenderer {
+    type ScenePainter<'a>
+        = VelloScenePainter<'a, 'a>
+    where
+        Self: 'a;
+
+    fn new(width: u32, height: u32) -> Self {
+        Self::with_pipeline_cache(width, height, None)
     }
 
     fn resize(&mut self, width: u32, height: u32) {

--- a/crates/anyrender_vello/src/window_renderer.rs
+++ b/crates/anyrender_vello/src/window_renderer.rs
@@ -12,7 +12,8 @@ use vello::{
     Scene as VelloScene,
 };
 use wgpu::{
-    CompositeAlphaMode, Features, Limits, PresentMode, Texture, TextureFormat, TextureUsages,
+    CompositeAlphaMode, Features, Limits, PipelineCache, PresentMode, Texture, TextureFormat,
+    TextureUsages,
 };
 use wgpu_context::{
     AlphaConversion, DeviceHandle, SurfaceRenderer, SurfaceRendererConfiguration,
@@ -64,6 +65,10 @@ pub struct VelloRendererOptions {
     pub antialiasing_method: AaConfig,
     /// Alpha mode used when compositing the window surface.
     pub composite_alpha_mode: anyrender::CompositeAlphaMode,
+    /// Cache that wgpu may reuse compiled pipelines from, avoiding shader
+    /// compilation on start-up. Creating it, persisting its data and deciding
+    /// when it is stale are all the caller's responsibility.
+    pub pipeline_cache: Option<PipelineCache>,
 }
 
 impl Default for VelloRendererOptions {
@@ -80,40 +85,48 @@ impl VelloRendererOptions {
             base_color: Color::WHITE,
             antialiasing_method: AaConfig::Msaa16,
             composite_alpha_mode: anyrender::CompositeAlphaMode::Auto,
+            pipeline_cache: None,
         }
     }
 
-    pub const fn features(self, features: Features) -> Self {
+    pub fn features(self, features: Features) -> Self {
         Self {
             features: Some(features),
             ..self
         }
     }
 
-    pub const fn limits(self, limits: Limits) -> Self {
+    pub fn limits(self, limits: Limits) -> Self {
         Self {
             limits: Some(limits),
             ..self
         }
     }
 
-    pub const fn base_color(self, base_color: Color) -> Self {
+    pub fn base_color(self, base_color: Color) -> Self {
         Self { base_color, ..self }
     }
 
-    pub const fn antialiasing_method(self, antialiasing_method: AaConfig) -> Self {
+    pub fn antialiasing_method(self, antialiasing_method: AaConfig) -> Self {
         Self {
             antialiasing_method,
             ..self
         }
     }
 
-    pub const fn composite_alpha_mode(
+    pub fn composite_alpha_mode(
         self,
         composite_alpha_mode: anyrender::types::CompositeAlphaMode,
     ) -> Self {
         Self {
             composite_alpha_mode,
+            ..self
+        }
+    }
+
+    pub fn pipeline_cache(self, pipeline_cache: PipelineCache) -> Self {
+        Self {
+            pipeline_cache: Some(pipeline_cache),
             ..self
         }
     }
@@ -273,6 +286,7 @@ impl WindowRenderer for VelloWindowRenderer {
                 }
             }
         };
+        let pipeline_cache = self.config.pipeline_cache.clone();
         let existing_device_handle = self
             .wgpu_context
             .find_compatible_device_handle(Some(&surface));
@@ -360,7 +374,7 @@ impl WindowRenderer for VelloWindowRenderer {
                     antialiasing_support: AaSupport::all(),
                     use_cpu: false,
                     num_init_threads: DEFAULT_THREADS,
-                    pipeline_cache: None,
+                    pipeline_cache,
                 },
             )
             .unwrap();


### PR DESCRIPTION
Closes #72.

`vello::RendererOptions` has taken a `pipeline_cache` for a while. Both renderers here hardcoded it to `None`, and `VelloRendererOptions` had no field to set it from, so the cache was unreachable through this crate no matter what the consumer wanted.

## What changed

- `VelloRendererOptions` grows `pipeline_cache: Option<wgpu::PipelineCache>`, with a matching builder method.
- `VelloWindowRenderer` passes it to `VelloRenderer::new` on resume.
- `VelloImageRenderer::with_pipeline_cache` covers the image path. `ImageRenderer::new` takes only width and height, so an inherent constructor was the way in; `new` now delegates to it with `None`.

Both default to `None`, so nothing changes for existing callers. Serialising the cache data and deciding when it is stale stay with the consumer — that needs a file path and an invalidation policy this crate should not have to guess.

## One cost, stated up front

Holding a `PipelineCache` gives `VelloRendererOptions` a destructor, and a `const fn` cannot take such a type by value. The builder methods added in #71 therefore lose their `const`. `VelloRendererOptions::new` keeps it.

I tried to avoid this — destructuring `self` rather than using `..self` does not help, because the restriction is on the parameter, not the move. If that constness is worth keeping, the alternative is to leave the options struct alone and hang the cache off the renderers directly, mirroring `with_pipeline_cache` on the window side. Happy to switch if you prefer that shape.

## What is and is not verified

The workspace builds, `cargo clippy --workspace --all-targets` is clean, and the existing tests pass.

I have not measured a speedup, and cannot on this machine. `wgpu-hal`'s Metal `create_pipeline_cache` returns a unit-struct stub, as do DX12 and GLES; only Vulkan builds a real `vk::PipelineCacheCreateInfo`. So the concrete win is Vulkan/Linux, and this patch makes it reachable rather than demonstrating it. The macOS numbers in #72 — 1949 ms to first paint with the OS Metal cache cleared against 233 ms warm — are what sent me looking, but that speedup comes from the OS cache and would not change here either way.
