### PR TITLE
Fix build on 32-bit architectures

### DIFF
--- a/crates/anyrender/src/filters.rs
+++ b/crates/anyrender/src/filters.rs
@@ -428,9 +428,9 @@ pub enum FilterEffect {
 
 // Assert size of FilterEffect.
 // This is just for documentation purposes. Feel free to update the value as necessary
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(target_pointer_width = "64")]
 const _: [u8; 128] = [0; std::mem::size_of::<FilterEffect>()];
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_pointer_width = "32")]
 const _: [u8; 88] = [0; std::mem::size_of::<FilterEffect>()];
 
 impl FilterEffect {


### PR DESCRIPTION
Fix FilterEffect size assertion on 32-bit targets in general, not just wasm. We ran into this with i686-pc-windows-msvc.