### PR TITLE
Skia: hold image Blob alongside cached image shader

### DIFF
--- a/crates/anyrender_skia/src/scene.rs
+++ b/crates/anyrender_skia/src/scene.rs
@@ -31,7 +31,9 @@ pub struct SkiaSceneCache {
     extracted_font_data: GenerationalCache<(u64, u32), peniko::FontData>,
     typeface: GenerationalCache<(u64, u32), Typeface>,
     normalized_typeface: GenerationalCache<NormalizedTypefaceCacheKey, Typeface>,
-    image_shader: GenerationalCache<u64, Shader>,
+    // The `Blob` is held alongside the `Shader` because the shader references the
+    // image pixels without owning them (see `shader_from_image_brush`).
+    image_shader: GenerationalCache<u64, (Shader, peniko::Blob<u8>)>,
     font: GenerationalCache<FontCacheKey, Font>,
     font_mgr: FontMgr,
     glyph_id_buf: Vec<GlyphId>,
@@ -142,7 +144,8 @@ impl SkiaScenePainter<'_> {
                     .set_shader(sk_peniko::shader_from_gradient(gradient, brush_transform));
             }
             anyrender::Paint::Image(image_brush) => {
-                if let Some(shader) = self.cache.image_shader.hit(&image_brush.image.data.id()) {
+                if let Some((shader, _)) = self.cache.image_shader.hit(&image_brush.image.data.id())
+                {
                     self.cache.paint.set_shader(shader.clone());
                     return;
                 }
@@ -150,9 +153,10 @@ impl SkiaScenePainter<'_> {
                 let image_shader = sk_peniko::shader_from_image_brush(image_brush, brush_transform);
 
                 if let Some(shader) = &image_shader {
-                    self.cache
-                        .image_shader
-                        .insert(image_brush.image.data.id(), shader.clone());
+                    self.cache.image_shader.insert(
+                        image_brush.image.data.id(),
+                        (shader.clone(), image_brush.image.data.clone()),
+                    );
                 }
 
                 self.cache.paint.set_shader(image_shader);


### PR DESCRIPTION
## Summary
`shader_from_image_brush` builds the Skia image via `unsafe { SkData::new_bytes(...) }`, which references the peniko `Blob`'s pixel bytes without owning them. The resulting shader is stored in the generational `image_shader` cache, which outlives the `set_paint_brush` call — so if the caller drops the `ImageData` after painting, the cached shader dangles (UB).

Fix: change the cache value from `Shader` to `(Shader, peniko::Blob<u8>)` and store a clone of the image blob (a cheap `Arc` clone) alongside the shader, tying the pixel data's lifetime to the cache entry.

Note: the cache key still ignores `brush_transform`/sampler (audit item 1.2); that's a separate issue not addressed here.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/b0ca09237beb462e9ea6b7be54018019
Requested by: @nicoburns