### PR TITLE
anyrender_svg: don't apply text transform twice

### DIFF
--- a/crates/anyrender_svg/src/render.rs
+++ b/crates/anyrender_svg/src/render.rs
@@ -135,10 +135,13 @@ pub(crate) fn render_group<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
                 }
             }
             usvg::Node::Text(text) => {
+                // The children of the flattened text group already carry the
+                // text node's absolute transform, so recurse with the identity
+                // transform (like the group case) to avoid applying it twice.
                 render_group(
                     scene,
                     text.flattened(),
-                    transform,
+                    Affine::IDENTITY,
                     global_transform,
                     error_handler,
                 );


### PR DESCRIPTION
## Summary
SVG `<text>` was rendered with its transform applied twice, so text on e.g. shields.io badges (`https://img.shields.io/crates/v/blitz.svg`, which wraps text in `<g transform="scale(.1)">` with `font-size="110"`) ended up 100× too small and mispositioned (effectively invisible).

In `render_group`, each child's `abs_transform()` is pre-multiplied into `transform` before dispatch. The children of `usvg::Text::flattened()` already carry the text node's absolute transform, so the `Node::Text` branch must recurse with `Affine::IDENTITY` (as the `Node::Group` branch does), not with the accumulated `transform`:

```diff
 usvg::Node::Text(text) => {
-    render_group(scene, text.flattened(), transform, global_transform, error_handler);
+    render_group(scene, text.flattened(), Affine::IDENTITY, global_transform, error_handler);
 }
```

Verified via Blitz's screenshot example: badge text now renders identically to resvg's reference output.

Before / after (rendered by Blitz):

![before](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvYzA3MzY5NjQtNGUxMC00NjY0LThmMTMtZWQ2MmE5YmZmN2I3IiwiaWF0IjoxNzg2MTU3MzYwLCJleHAiOjE3ODY3NjIxNjAsImZpbGVuYW1lIjoiYmVmb3JlLnBuZyJ9.Dm7t3S-P-IbktLfMVuinbfPCYSraGZ8RLeCgI64-fSc)
![after](https://staging.itsdev.in/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNGU2MjgwYTVkNjZkNDFhMTkyYTUxNWQwY2FiODcyZjIvNjRhNWZkODMtMjkzNy00NTE0LWEzYmEtZWI5NGU1NzI5MmJkIiwiaWF0IjoxNzg2MTU3MzYwLCJleHAiOjE3ODY3NjIxNjAsImZpbGVuYW1lIjoiYWZ0ZXIucG5nIn0.E78P45KeMHYOtmKW0gxO3l0V23NfRrmU-W8p8b4HdYk)

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/e3ee5d93814646ef9f657861d05792d9
Requested by: @nicoburns