### PR TITLE
Align MSRV references on Rust 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
   # We only run `cargo build` (not `cargo test`) so as to avoid requiring dev-dependencies to build with the MSRV
   # version. Building is likely sufficient as runtime errors varying between rust versions is very unlikely.
   build-msrv:
-    name: "MSRV Build [Rust 1.92]"
+    name: "MSRV Build [Rust 1.88]"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.92
+          toolchain: 1.88
       - name: Install development libraries on ubuntu
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libfreetype6-dev
       - run: cargo build --workspace

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ crates in your project.
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of AnyRender has been verified to compile with **Rust 1.86** and later.
+This version of AnyRender has been verified to compile with **Rust 1.88** and later.
 
 Future versions of AnyRender might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.


### PR DESCRIPTION
## Summary

MSRV was inconsistent across the repo: workspace `Cargo.toml` said `rust-version = "1.88.0"`, the CI MSRV job pinned 1.92, and the README claimed 1.86. Both now say 1.88, matching `Cargo.toml`.

- `.github/workflows/ci.yml`: `build-msrv` job name and `toolchain` → 1.88
- `README.md`: MSRV section → **Rust 1.88**


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/87728e979ab24ba382af6779dec6f663
Requested by: @nicoburns