### PR TITLE
Update skia-safe to 0.99

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
+checksum = "3e2d1c3ebd697c0cbded0145e9204a38fa6b268446051b7196d0a096414ea7f3"
 dependencies = [
  "bindgen",
  "cc",
@@ -3361,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.97.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
+checksum = "9f512ac418a64194842dd05566320805dad1c957c521039db2486fd6368865bc"
 dependencies = [
  "bitflags 2.11.1",
  "skia-bindings",

--- a/crates/anyrender_skia/Cargo.toml
+++ b/crates/anyrender_skia/Cargo.toml
@@ -22,7 +22,7 @@ peniko = { workspace = true }
 raw-window-handle = { workspace = true }
 softbuffer_window_renderer = { workspace = true, optional = true }
 pixels_window_renderer = { workspace = true, optional = true }
-skia-safe = { version = "0.97.0", features = ["gl", "pdf", "textlayout"]}
+skia-safe = { version = "0.99.0", features = ["gl", "pdf", "textlayout"]}
 oaty = "0.2"
 hashbrown = "0.17.0"
 
@@ -43,4 +43,4 @@ objc2 = { version = "0.6.3", default-features = false }
 objc2-core-foundation = { version = "0.3.2", default-features = false }
 objc2-metal = { version = "0.3.2", default-features = false, features = ["MTLCommandBuffer", "MTLCommandQueue", "MTLDrawable", "MTLPixelFormat"] }
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["objc2-core-foundation", "objc2-metal", "CAMetalLayer"] }
-skia-safe = { version = "0.97.2", features = ["metal"] }
+skia-safe = { version = "0.99.0", features = ["metal"] }

--- a/crates/anyrender_skia/src/vulkan.rs
+++ b/crates/anyrender_skia/src/vulkan.rs
@@ -783,16 +783,17 @@ fn create_gr_context(
         }
     };
 
-    let mut backend_context = unsafe {
-        BackendContext::new(
+    let backend_context = unsafe {
+        BackendContext::new_builder(
             instance.handle().as_raw() as _,
             physical_device.as_raw() as _,
             device.handle().as_raw() as _,
             (queue.as_raw() as _, queue_family_index as usize),
             &get_proc,
+            Some(Version::new(1, 1, 0)),
         )
+        .build()
     };
-    backend_context.set_max_api_version(Version::new(1, 1, 0));
 
     let context_options = ContextOptions::default();
 


### PR DESCRIPTION
## Summary
Bumps `skia-safe` from 0.97 to 0.99 (latest) in `anyrender_skia`.

The only API change affecting us: `gpu::vk::BackendContext::new` was deprecated in 0.98 in favor of a builder, so the Vulkan backend's `create_gr_context` now uses:

```rust
BackendContext::new_builder(instance, physical_device, device, (queue, queue_index), &get_proc, Some(Version::new(1, 1, 0))).build()
```

replacing the old `BackendContext::new(...)` + `set_max_api_version(Version::new(1, 1, 0))` pair (the builder applies the max API version during native context creation).

skia-safe 0.99's MSRV is 1.85, below our 1.88.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/45e0faec687f43dab4877d3793843287
Requested by: @nicoburns