### PR TITLE
Release AnyRender 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "kurbo",
  "peniko",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender_serialize"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyrender",
  "image",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender_skia"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyrender",
  "ash",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender_svg"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyrender",
  "image",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello_cpu"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello_hybrid"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "pixels_window_renderer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "softbuffer_window_renderer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_context"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "futures-intrusive",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,16 +26,16 @@ rust-version = "1.88.0"
 
 [workspace.dependencies]
 # AnyRender dependencies (in-repo)
-anyrender = { version = "0.12.0", path = "./crates/anyrender" }
-anyrender_serialize = { version = "0.6.0", path = "./crates/anyrender_serialize" }
-anyrender_skia = { version = "0.10.0", path = "./crates/anyrender_skia" }
-anyrender_vello = { version = "0.13.0", path = "./crates/anyrender_vello" }
-anyrender_vello_cpu = { version = "0.15.0", path = "./crates/anyrender_vello_cpu" }
-anyrender_vello_hybrid = { version = "0.9.0", path = "./crates/anyrender_vello_hybrid" }
-anyrender_svg = { version = "0.13.0", path = "./crates/anyrender_svg" }
-wgpu_context = { version = "0.8.0", path = "./crates/wgpu_context" }
-pixels_window_renderer = { version = "0.7.0", path = "./crates/pixels_window_renderer" }
-softbuffer_window_renderer = { version = "0.7.0", path = "./crates/softbuffer_window_renderer" }
+anyrender = { version = "0.13.0", path = "./crates/anyrender" }
+anyrender_serialize = { version = "0.7.0", path = "./crates/anyrender_serialize" }
+anyrender_skia = { version = "0.11.0", path = "./crates/anyrender_skia" }
+anyrender_vello = { version = "0.14.0", path = "./crates/anyrender_vello" }
+anyrender_vello_cpu = { version = "0.16.0", path = "./crates/anyrender_vello_cpu" }
+anyrender_vello_hybrid = { version = "0.10.0", path = "./crates/anyrender_vello_hybrid" }
+anyrender_svg = { version = "0.14.0", path = "./crates/anyrender_svg" }
+wgpu_context = { version = "0.9.0", path = "./crates/wgpu_context" }
+pixels_window_renderer = { version = "0.8.0", path = "./crates/pixels_window_renderer" }
+softbuffer_window_renderer = { version = "0.8.0", path = "./crates/softbuffer_window_renderer" }
 
 # Serialization
 serde = "1.0.228"

--- a/README.md
+++ b/README.md
@@ -59,32 +59,32 @@ crates in your project.
 
 <table>
   <thead>
-    <tr><th>AnyRender</th><th>0.6</th><th>0.7</th><th>0.8</th><th>0.9</th><th>0.10</th><th>0.11</th><th>0.12</th></tr>
+    <tr><th>AnyRender</th><th>0.6</th><th>0.7</th><th>0.8</th><th>0.9</th><th>0.10</th><th>0.11</th><th>0.12</th><th>0.13</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>kurbo</code></td><td>0.12</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td></tr>
-    <tr><td><code>peniko</code></td><td>0.5</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td></tr>
-    <tr><th colspan="8" align=left>WGPU</th></tr>
-    <tr><td><code>wgpu</code></td><td>26</td><td>27</td><td>28</td><td>28</td><td>29</td><td>29</td><td>29</td></tr>
-    <tr><td><code>wgpu_context</code></td><td>0.1</td><td>0.2</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.6–0.7</td><td>0.8</td></tr>
-    <tr><th colspan="8" align=left>Vello</th></tr>
-    <tr><td><code>anyrender_vello</code></td><td>0.6</td><td>0.7</td><td>0.8</td><td>0.9</td><td>0.10</td><td>0.11–0.12</td><td>0.13</td></tr>
-    <tr><td><code>vello</code></td><td>0.6</td><td>0.7 <sup><a href="#fn-vello-git">1</a></sup></td><td>0.8</td><td>0.8</td><td>0.9</td><td>0.9</td><td>0.9</td></tr>
-    <tr><th colspan="8" align=left>Vello Hybrid</th></tr>
-    <tr><td><code>vello_hybrid</code></td><td>0.0.4</td><td>0.0.6</td><td>0.0.7</td><td>0.0.7</td><td>0.0.8</td><td>0.0.9</td><td>0.0.9</td></tr>
-    <tr><td><code>anyrender_vello_hybrid</code></td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.4</td><td>0.5</td><td>0.7–0.8</td><td>0.9</td></tr>
-    <tr><th colspan="8" align=left>Vello CPU</th></tr>
-    <tr><td><code>vello_cpu</code></td><td>0.0.4</td><td>0.0.6</td><td>0.0.7</td><td>0.0.7</td><td>0.0.8</td><td>0.0.9</td><td>0.0.9</td></tr>
-    <tr><td><code>anyrender_vello_cpu</code></td><td>0.8</td><td>0.9</td><td>0.10</td><td>0.11</td><td>0.12</td><td>0.14</td><td>0.15</td></tr>
-    <tr><th colspan="8" align=left>Skia</th></tr>
-    <tr><td><code>skia-safe</code></td><td>0.89</td><td>0.91</td><td>0.93</td><td>0.93</td><td>0.93 <sup><a href="#fn-skia-097">2</a></sup></td><td>0.97</td><td>0.97</td></tr>
-    <tr><td><code>anyrender_skia</code></td><td>0.1</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.7</td><td>0.9</td><td>0.10</td></tr>
-    <tr><th colspan="8" align=left>Content Libs</th></tr>
-    <tr><td><code>anyrender_svg</code></td><td>0.6</td><td>0.8</td><td>0.9</td><td>0.10</td><td>0.11</td><td>0.12</td><td>0.13</td></tr>
-    <tr><td><code>anyrender_serialize</code></td><td>—</td><td>—</td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.5</td><td>0.6</td></tr>
-    <tr><th colspan="8" align=left>CPU <code>WindowRenderer</code>s</th></tr>
-    <tr><td><code>pixels_window_renderer</code></td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.7</td></tr>
-    <tr><td><code>softbuffer_window_renderer</code></td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.7</td></tr>
+    <tr><td><code>kurbo</code></td><td>0.12</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td><td>0.13</td></tr>
+    <tr><td><code>peniko</code></td><td>0.5</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td><td>0.6</td></tr>
+    <tr><th colspan="9" align=left>WGPU</th></tr>
+    <tr><td><code>wgpu</code></td><td>26</td><td>27</td><td>28</td><td>28</td><td>29</td><td>29</td><td>29</td><td>29</td></tr>
+    <tr><td><code>wgpu_context</code></td><td>0.1</td><td>0.2</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.6–0.7</td><td>0.8</td><td>0.9</td></tr>
+    <tr><th colspan="9" align=left>Vello</th></tr>
+    <tr><td><code>anyrender_vello</code></td><td>0.6</td><td>0.7</td><td>0.8</td><td>0.9</td><td>0.10</td><td>0.11–0.12</td><td>0.13</td><td>0.14</td></tr>
+    <tr><td><code>vello</code></td><td>0.6</td><td>0.7 <sup><a href="#fn-vello-git">1</a></sup></td><td>0.8</td><td>0.8</td><td>0.9</td><td>0.9</td><td>0.9</td><td>0.10</td></tr>
+    <tr><th colspan="9" align=left>Vello Hybrid</th></tr>
+    <tr><td><code>vello_hybrid</code></td><td>0.0.4</td><td>0.0.6</td><td>0.0.7</td><td>0.0.7</td><td>0.0.8</td><td>0.0.9</td><td>0.0.9</td><td>0.1</td></tr>
+    <tr><td><code>anyrender_vello_hybrid</code></td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.4</td><td>0.5</td><td>0.7–0.8</td><td>0.9</td><td>0.10</td></tr>
+    <tr><th colspan="9" align=left>Vello CPU</th></tr>
+    <tr><td><code>vello_cpu</code></td><td>0.0.4</td><td>0.0.6</td><td>0.0.7</td><td>0.0.7</td><td>0.0.8</td><td>0.0.9</td><td>0.0.9</td><td>0.1</td></tr>
+    <tr><td><code>anyrender_vello_cpu</code></td><td>0.8</td><td>0.9</td><td>0.10</td><td>0.11</td><td>0.12</td><td>0.14</td><td>0.15</td><td>0.16</td></tr>
+    <tr><th colspan="9" align=left>Skia</th></tr>
+    <tr><td><code>skia-safe</code></td><td>0.89</td><td>0.91</td><td>0.93</td><td>0.93</td><td>0.93 <sup><a href="#fn-skia-097">2</a></sup></td><td>0.97</td><td>0.97</td><td>0.99</td></tr>
+    <tr><td><code>anyrender_skia</code></td><td>0.1</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.7</td><td>0.9</td><td>0.10</td><td>0.11</td></tr>
+    <tr><th colspan="9" align=left>Content Libs</th></tr>
+    <tr><td><code>anyrender_svg</code></td><td>0.6</td><td>0.8</td><td>0.9</td><td>0.10</td><td>0.11</td><td>0.12</td><td>0.13</td><td>0.14</td></tr>
+    <tr><td><code>anyrender_serialize</code></td><td>—</td><td>—</td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.5</td><td>0.6</td><td>0.7</td></tr>
+    <tr><th colspan="9" align=left>CPU <code>WindowRenderer</code>s</th></tr>
+    <tr><td><code>pixels_window_renderer</code></td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.7</td><td>0.8</td></tr>
+    <tr><td><code>softbuffer_window_renderer</code></td><td>0.1</td><td>0.2</td><td>0.3</td><td>0.4</td><td>0.5</td><td>0.6</td><td>0.7</td><td>0.8</td></tr>
   </tbody>
 </table>
 

--- a/crates/anyrender/CHANGELOG.md
+++ b/crates/anyrender/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-08-16
+
+### Fixed
+
+- `FilterEffect` size assertion on 32-bit targets in general, not just wasm (#74).
+
 ## [0.12.0] - 2026-07-23
 
 ### Added

--- a/crates/anyrender/Cargo.toml
+++ b/crates/anyrender/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender"
 description = "2D Canvas abstraction"
-version = "0.12.0"
+version = "0.13.0"
 documentation = "https://docs.rs/anyrender"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/anyrender_serialize/CHANGELOG.md
+++ b/crates/anyrender_serialize/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-16
+
+### Changed
+
+- Upgraded `skera` to 0.4 and `read-fonts` to 0.41, deduplicating the font stack (#80).
+
 ## [0.6.0] - 2026-07-23
 
 ### Changed

--- a/crates/anyrender_serialize/Cargo.toml
+++ b/crates/anyrender_serialize/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender_serialize"
 description = "Serialization of recorded scenes to a portable zip format"
-version = "0.6.0"
+version = "0.7.0"
 documentation = "https://docs.rs/anyrender"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/anyrender_skia/CHANGELOG.md
+++ b/crates/anyrender_skia/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-08-16
+
+### Changed
+
+- Upgraded `skia-safe` to 0.99 (#82).
+
+### Fixed
+
+- Rounded rect corner radii mapping (#76).
+- Box shadow blurs now respect the current transformation matrix (#75).
+- The image `Blob` is now held alongside the cached image shader, preventing use-after-free of image data (#77).
+
 ## [0.10.0] - 2026-07-23
 
 ### Added

--- a/crates/anyrender_skia/Cargo.toml
+++ b/crates/anyrender_skia/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender_skia"
 description = "Skia backend for anyrender"
-version = "0.10.0"
+version = "0.11.0"
 documentation = "https://docs.rs/anyrender_skia"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/anyrender_svg/CHANGELOG.md
+++ b/crates/anyrender_svg/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-08-16
+
+### Changed
+
+- Upgraded `usvg` to 0.48.1 (#78).
+
 ## [0.13.0] - 2026-07-23
 
 ### Changed

--- a/crates/anyrender_svg/Cargo.toml
+++ b/crates/anyrender_svg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender_svg"
 description = "Render SVGs with anyrender"
-version = "0.13.0"
+version = "0.14.0"
 documentation = "https://docs.rs/anyrender-svg"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/anyrender_vello/CHANGELOG.md
+++ b/crates/anyrender_vello/CHANGELOG.md
@@ -5,17 +5,26 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-08-16
+
+### Added
+
+- `pipeline_cache` on `VelloRendererOptions`, and `VelloImageRenderer::with_pipeline_cache`, so a `wgpu::PipelineCache` can reach Vello (#73).
+
+### Changed
+
+- Upgraded `vello` to 0.10 (#80).
+- `VelloRendererOptions`' builder methods are no longer `const`, because the options now hold a type with a destructor (#73).
+
 ## [0.13.0] - 2026-07-23
 
 ### Added
 
 - Configurable composite alpha mode and base color via `VelloRendererOptions`, with builder-pattern methods (#71).
-- `pipeline_cache` on `VelloRendererOptions`, and `VelloImageRenderer::with_pipeline_cache`, so a `wgpu::PipelineCache` can reach Vello (#73).
 
 ### Changed
 
 - Marked `VelloRendererOptions` as `#[non_exhaustive]` (#71).
-- `VelloRendererOptions`' builder methods are no longer `const`, because the options now hold a type with a destructor (#73).
 
 ## [0.12.0] - 2026-06-23
 

--- a/crates/anyrender_vello/Cargo.toml
+++ b/crates/anyrender_vello/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender_vello"
 description = "Vello backend for anyrender"
-version = "0.13.0"
+version = "0.14.0"
 documentation = "https://docs.rs/anyrender_vello"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/anyrender_vello_cpu/CHANGELOG.md
+++ b/crates/anyrender_vello_cpu/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-08-16
+
+### Changed
+
+- Upgraded `vello_cpu` to 0.1 (#80).
+
 ## [0.15.0] - 2026-07-23
 
 ### Added

--- a/crates/anyrender_vello_cpu/Cargo.toml
+++ b/crates/anyrender_vello_cpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender_vello_cpu"
 description = "vello_cpu backend for anyrender"
-version = "0.15.0"
+version = "0.16.0"
 documentation = "https://docs.rs/anyrender_vello_cpu"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/anyrender_vello_hybrid/CHANGELOG.md
+++ b/crates/anyrender_vello_hybrid/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-08-16
+
+### Changed
+
+- Upgraded `vello_hybrid` to 0.1 (#80).
+
 ## [0.9.0] - 2026-07-23
 
 ### Added

--- a/crates/anyrender_vello_hybrid/Cargo.toml
+++ b/crates/anyrender_vello_hybrid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "anyrender_vello_hybrid"
 description = "vello_hybrid backend for anyrender"
-version = "0.9.0"
+version = "0.10.0"
 documentation = "https://docs.rs/anyrender_vello_hybrid"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/pixels_window_renderer/CHANGELOG.md
+++ b/crates/pixels_window_renderer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-08-16
+
+### Changed
+
+- Version bump for the AnyRender 0.13 release.
+
 ## [0.7.0] - 2026-07-23
 
 ### Added

--- a/crates/pixels_window_renderer/Cargo.toml
+++ b/crates/pixels_window_renderer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixels_window_renderer"
 description = "AnyRender WindowRenderer backed by the pixels crate"
-version = "0.7.0"
+version = "0.8.0"
 documentation = "https://docs.rs/pixels_window_renderer"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/softbuffer_window_renderer/CHANGELOG.md
+++ b/crates/softbuffer_window_renderer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-08-16
+
+### Changed
+
+- Version bump for the AnyRender 0.13 release.
+
 ## [0.7.0] - 2026-07-23
 
 ### Added

--- a/crates/softbuffer_window_renderer/Cargo.toml
+++ b/crates/softbuffer_window_renderer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "softbuffer_window_renderer"
 description = "AnyRender WindowRenderer backed by the softbuffer crate"
-version = "0.7.0"
+version = "0.8.0"
 documentation = "https://docs.rs/softbuffer_window_renderer"
 homepage.workspace = true
 repository.workspace = true

--- a/crates/wgpu_context/CHANGELOG.md
+++ b/crates/wgpu_context/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-08-16
+
+### Changed
+
+- Version bump for the AnyRender 0.13 release.
+
 ## [0.8.0] - 2026-07-23
 
 ### Added

--- a/crates/wgpu_context/Cargo.toml
+++ b/crates/wgpu_context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgpu_context"
 description = "Context for managing WGPU surfaces"
-version = "0.8.0"
+version = "0.9.0"
 documentation = "https://docs.rs/wgpu_context"
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

Release commit for the AnyRender 0.13 line: version bumps across all 10 crates, changelog entries dated 2026-08-16, and a new 0.13 column in the README version compatibility table.

Version bumps:

| Crate | Old | New |
|---|---|---|
| `anyrender` | 0.12.0 | 0.13.0 |
| `anyrender_vello` | 0.13.0 | 0.14.0 |
| `anyrender_vello_cpu` | 0.15.0 | 0.16.0 |
| `anyrender_vello_hybrid` | 0.9.0 | 0.10.0 |
| `anyrender_skia` | 0.10.0 | 0.11.0 |
| `anyrender_svg` | 0.13.0 | 0.14.0 |
| `anyrender_serialize` | 0.6.0 | 0.7.0 |
| `wgpu_context` | 0.8.0 | 0.9.0 |
| `pixels_window_renderer` | 0.7.0 | 0.8.0 |
| `softbuffer_window_renderer` | 0.7.0 | 0.8.0 |

Notable content since 0.12: Vello 0.10 / vello_cpu 0.1 / vello_hybrid 0.1 (#80), skia-safe 0.99 (#82), usvg 0.48.1 (#78), wgpu `PipelineCache` support in the Vello backend (#73), Skia backend fixes (#75, #76, #77), and a 32-bit build fix (#74).

Note: #73's changelog entries had landed under the already-published `anyrender_vello` 0.13.0 section; they are moved to the new 0.14.0 section here.

A draft GitHub release for v0.13.0 accompanies this PR (to be published after merge + crates.io publish).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6b35de72d7f14984b4996aaab6bef680
Requested by: @nicoburns