### PR TITLE
Fix radial gradient focal/center mapping in anyrender_svg

### DIFF
--- a/crates/anyrender_svg/src/util.rs
+++ b/crates/anyrender_svg/src/util.rs
@@ -184,9 +184,9 @@ pub(crate) fn to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(P
                 })
                 .collect();
 
-            let start_center = Point::new(gr.cx() as f64, gr.cy() as f64);
-            let end_center = Point::new(gr.fx() as f64, gr.fy() as f64);
-            let start_radius = 0_f32;
+            let start_center = Point::new(gr.fx() as f64, gr.fy() as f64);
+            let end_center = Point::new(gr.cx() as f64, gr.cy() as f64);
+            let start_radius = gr.fr().get();
             let end_radius = gr.r().get();
             let arr = [
                 gr.transform().sx,


### PR DESCRIPTION
## Summary
`to_brush` in anyrender_svg built two-point radial gradients with the focal and center points swapped and the focal radius `fr` dropped:

```diff
- start = (cx, cy), r = 0
- end   = (fx, fy), r = gr.r()
+ start = (fx, fy), r = gr.fr()   // focal circle
+ end   = (cx, cy), r = gr.r()    // center circle
```

This matches resvg's `convert_radial_gradient` mapping for `peniko::Gradient::new_two_point_radial(focal_center, fr, center, r)`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/80f59193112d47168eafc56c78c33935
Requested by: @nicoburns