### PR TITLE
Support SVG `image-rendering` property for raster images

### DIFF
--- a/crates/anyrender_svg/src/render.rs
+++ b/crates/anyrender_svg/src/render.rs
@@ -112,7 +112,7 @@ pub(crate) fn render_group<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
                                 error_handler(scene, node);
                                 continue;
                             };
-                            let image = util::into_image(decoded_image);
+                            let image = util::into_image(decoded_image, img.rendering_mode());
                             let image_ts = global_transform * util::to_affine(&img.abs_transform());
                             scene.draw_image(image.as_ref(), image_ts);
                         }

--- a/crates/anyrender_svg/src/util.rs
+++ b/crates/anyrender_svg/src/util.rs
@@ -122,10 +122,10 @@ pub(crate) fn into_image(
     use peniko::ImageData;
 
     let quality = match rendering_mode {
-        usvg::ImageRendering::OptimizeQuality | usvg::ImageRendering::HighQuality => {
-            peniko::ImageQuality::High
+        usvg::ImageRendering::HighQuality => peniko::ImageQuality::High,
+        usvg::ImageRendering::OptimizeQuality | usvg::ImageRendering::Smooth => {
+            peniko::ImageQuality::Medium
         }
-        usvg::ImageRendering::Smooth => peniko::ImageQuality::Medium,
         usvg::ImageRendering::OptimizeSpeed
         | usvg::ImageRendering::CrispEdges
         | usvg::ImageRendering::Pixelated => peniko::ImageQuality::Low,

--- a/crates/anyrender_svg/src/util.rs
+++ b/crates/anyrender_svg/src/util.rs
@@ -115,8 +115,21 @@ pub(crate) fn to_bez_path(path: &usvg::Path) -> BezPath {
 }
 
 #[cfg(feature = "image")]
-pub(crate) fn into_image(image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>) -> ImageBrush {
+pub(crate) fn into_image(
+    image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>,
+    rendering_mode: usvg::ImageRendering,
+) -> ImageBrush {
     use peniko::ImageData;
+
+    let quality = match rendering_mode {
+        usvg::ImageRendering::OptimizeQuality | usvg::ImageRendering::HighQuality => {
+            peniko::ImageQuality::High
+        }
+        usvg::ImageRendering::Smooth => peniko::ImageQuality::Medium,
+        usvg::ImageRendering::OptimizeSpeed
+        | usvg::ImageRendering::CrispEdges
+        | usvg::ImageRendering::Pixelated => peniko::ImageQuality::Low,
+    };
 
     let (width, height) = (image.width(), image.height());
     let image_data: Vec<u8> = image.into_vec();
@@ -127,6 +140,7 @@ pub(crate) fn into_image(image: image::ImageBuffer<image::Rgba<u8>, Vec<u8>>) ->
         width,
         height,
     })
+    .with_quality(quality)
 }
 
 pub(crate) fn to_brush(paint: &usvg::Paint, opacity: usvg::Opacity) -> Option<(Paint, Affine)> {


### PR DESCRIPTION
## Summary
Raster `<image>` elements previously ignored the SVG `image-rendering` property. `util::into_image` now takes the node's `usvg::ImageRendering` and sets `peniko::ImageQuality` on the `ImageBrush` sampler (via `with_quality`):

- `HighQuality` → `High`
- `OptimizeQuality` / `Smooth` → `Medium`
- `OptimizeSpeed` / `CrispEdges` / `Pixelated` → `Low`

`OptimizeQuality` (the usvg resolution of `auto`) maps to `Medium` to match blitz-paint's `to_image_quality` default (`Auto → Medium`).

`render.rs` passes `img.rendering_mode()` through at the single call site.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/85756634062a40a88304b2cbb86cd6ef
Requested by: @nicoburns