### PR TITLE
SVG: Fix group fallback clipp (issue #88)

### DIFF
--- a/crates/anyrender_svg/src/lib.rs
+++ b/crates/anyrender_svg/src/lib.rs
@@ -86,48 +86,8 @@ pub fn render_svg_tree_with<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
 
 #[cfg(test)]
 mod tests {
-    use super::render_svg_str;
-    use anyrender::{Scene, recording::RenderCommand};
-    use kurbo::{Affine, Shape};
-
+    // CI will fail unless cargo nextest can execute at least one test per workspace.
+    // Delete this dummy test once we have an actual real test.
     #[test]
-    fn opacity_layer_clip_rect_covers_group_in_canvas_space() {
-        // A semi-transparent group nested inside a transformed parent group.
-        // The fallback opacity layer's clip rect must land where the group's
-        // content actually is on the canvas, outset by 2px on each side.
-        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
-          <g transform="translate(50,30) scale(2)">
-            <g opacity="0.5">
-              <rect x="10" y="10" width="20" height="20" fill="red"/>
-            </g>
-          </g>
-        </svg>"#;
-
-        let mut scene = Scene::new();
-        render_svg_str(&mut scene, svg, Affine::IDENTITY).unwrap();
-
-        let layer = scene
-            .commands
-            .iter()
-            .find_map(|cmd| match cmd {
-                RenderCommand::PushLayer(layer) => Some(layer),
-                _ => None,
-            })
-            .expect("expected an opacity layer to be pushed");
-
-        // Group content occupies (70, 50) to (110, 90) on the canvas
-        // (rect 10,10 20x20 mapped through translate(50,30) scale(2)),
-        // outset by 2px on each side.
-        let clip_bbox = layer
-            .transform
-            .transform_rect_bbox(layer.clip.bounding_box());
-        let expected = kurbo::Rect::new(68.0, 48.0, 112.0, 92.0);
-        assert!(
-            (clip_bbox.x0 - expected.x0).abs() < 1e-3
-                && (clip_bbox.y0 - expected.y0).abs() < 1e-3
-                && (clip_bbox.x1 - expected.x1).abs() < 1e-3
-                && (clip_bbox.y1 - expected.y1).abs() < 1e-3,
-            "clip bbox {clip_bbox:?} != expected {expected:?}"
-        );
-    }
+    fn dummy_test_until_we_have_a_real_test() {}
 }

--- a/crates/anyrender_svg/src/lib.rs
+++ b/crates/anyrender_svg/src/lib.rs
@@ -86,8 +86,48 @@ pub fn render_svg_tree_with<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
 
 #[cfg(test)]
 mod tests {
-    // CI will fail unless cargo nextest can execute at least one test per workspace.
-    // Delete this dummy test once we have an actual real test.
+    use super::render_svg_str;
+    use anyrender::{Scene, recording::RenderCommand};
+    use kurbo::{Affine, Shape};
+
     #[test]
-    fn dummy_test_until_we_have_a_real_test() {}
+    fn opacity_layer_clip_rect_covers_group_in_canvas_space() {
+        // A semi-transparent group nested inside a transformed parent group.
+        // The fallback opacity layer's clip rect must land where the group's
+        // content actually is on the canvas, outset by 2px on each side.
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+          <g transform="translate(50,30) scale(2)">
+            <g opacity="0.5">
+              <rect x="10" y="10" width="20" height="20" fill="red"/>
+            </g>
+          </g>
+        </svg>"#;
+
+        let mut scene = Scene::new();
+        render_svg_str(&mut scene, svg, Affine::IDENTITY).unwrap();
+
+        let layer = scene
+            .commands
+            .iter()
+            .find_map(|cmd| match cmd {
+                RenderCommand::PushLayer(layer) => Some(layer),
+                _ => None,
+            })
+            .expect("expected an opacity layer to be pushed");
+
+        // Group content occupies (70, 50) to (110, 90) on the canvas
+        // (rect 10,10 20x20 mapped through translate(50,30) scale(2)),
+        // outset by 2px on each side.
+        let clip_bbox = layer
+            .transform
+            .transform_rect_bbox(layer.clip.bounding_box());
+        let expected = kurbo::Rect::new(68.0, 48.0, 112.0, 92.0);
+        assert!(
+            (clip_bbox.x0 - expected.x0).abs() < 1e-3
+                && (clip_bbox.y0 - expected.y0).abs() < 1e-3
+                && (clip_bbox.x1 - expected.x1).abs() < 1e-3
+                && (clip_bbox.y1 - expected.y1).abs() < 1e-3,
+            "clip bbox {clip_bbox:?} != expected {expected:?}"
+        );
+    }
 }

--- a/crates/anyrender_svg/src/render.rs
+++ b/crates/anyrender_svg/src/render.rs
@@ -48,19 +48,25 @@ pub(crate) fn render_group<S: PaintScene, F: FnMut(&mut S, &usvg::Node)>(
                     // Else if there is blending to be done then push a layer with a rectangular clip
                     #[allow(deprecated)]
                     _ if mix != peniko::Mix::Normal || !is_fully_opaque => {
-                        // Use bounding box as the clip path.
+                        // Use the layer bounding box as the clip path. It is in the group's
+                        // content coordinate space, so map it to canvas space and outset it
+                        // by 2px on each side (like resvg) so anti-aliased pixels at the
+                        // layer edge aren't clipped.
                         let bounding_box = g.layer_bounding_box();
                         let rect = kurbo::Rect::from_origin_size(
-                            (bounding_box.x(), bounding_box.y()),
+                            (bounding_box.x() as f64, bounding_box.y() as f64),
                             (bounding_box.width() as f64, bounding_box.height() as f64),
                         );
+                        let rect = (global_transform * transform)
+                            .transform_rect_bbox(rect)
+                            .inflate(2.0, 2.0);
                         scene.push_layer(
                             BlendMode {
                                 mix,
                                 compose: peniko::Compose::SrcOver,
                             },
                             alpha,
-                            global_transform * transform,
+                            Affine::IDENTITY,
                             &rect,
                             None,
                             None,


### PR DESCRIPTION
## Summary

Addresses the opacity-layer clip rect item ("Correctness gaps" item 2) of #88, in `render_group`'s fallback branch that pushes a layer when `mix != Mix::Normal || !is_fully_opaque` and there is no single-path clip-path.

Investigation of usvg 0.48's source confirmed that `Group::layer_bounding_box()` is in the group's *content* coordinate space, and that `abs_layer_bounding_box = layer_bounding_box.transform(abs_transform)` where `abs_transform` *includes* the group's own transform. Since `transform` at that point in `render_group` is exactly `g.abs_transform()` (the recursion always passes `Affine::IDENTITY`), the existing `global_transform * transform` was already the correct mapping — verified empirically with a transformed-ancestor test SVG. So no transform-space bug existed here.

What was missing is resvg's 2px outset: resvg maps the layer bbox to canvas space and expands it by 2px on each side so anti-aliased pixels at the layer edge aren't clipped. This PR ports that:

```rust
let rect = (global_transform * transform)
    .transform_rect_bbox(rect)   // map layer bbox to canvas space
    .inflate(2.0, 2.0);          // 2px outset like resvg
scene.push_layer(.., alpha, Affine::IDENTITY, &rect, ..);
```

Mapping to canvas space first (and pushing with `Affine::IDENTITY`) makes the outset a fixed 2 device pixels, matching resvg, rather than 2 local units scaled by the transform.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/0d200578f2184979a1479dc012e6d29f
Requested by: @nicoburns